### PR TITLE
feat: Stats 지표 추가 (1)

### DIFF
--- a/alphastats/_utils.py
+++ b/alphastats/_utils.py
@@ -24,3 +24,10 @@ def to_lazy(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> pl.LazyFrame:
             ldf = returns
 
     return ldf.fill_nan(None)
+
+
+def to_excess_returns(expr: pl.Expr, rf: float | pl.Series | None) -> pl.Expr:
+    if not rf:
+        return expr
+
+    return expr.sub(rf)

--- a/alphastats/_utils.py
+++ b/alphastats/_utils.py
@@ -1,0 +1,26 @@
+import polars as pl
+import polars.selectors as cs
+
+RETURNS_COLUMNS_SELECTOR = cs.numeric()
+DT_COLUMNS_SELECTOR = cs.temporal()
+
+
+def get_dt_column(returns: pl.LazyFrame) -> pl.Expr:
+    column_names = cs.expand_selector(returns, DT_COLUMNS_SELECTOR)
+
+    if len(column_names) != 1:
+        raise ValueError(f"Must have exactly one temporal column. Found {column_names}")
+
+    return pl.col(column_names[0])
+
+
+def to_lazy(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> pl.LazyFrame:
+    match returns:
+        case pl.Series():
+            ldf = pl.LazyFrame(returns)
+        case pl.DataFrame():
+            ldf = returns.lazy()
+        case pl.LazyFrame():
+            ldf = returns
+
+    return ldf.fill_nan(None)

--- a/alphastats/stats.py
+++ b/alphastats/stats.py
@@ -18,10 +18,10 @@ def comp(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> float | pl.DataFra
     Compute total compounded returns.
 
     Args:
-        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
+        returns: Returns series or dataframe
 
     Returns:
-        float | pl.DataFrame: Compounded returns
+        Compounded return(s)
     """
     returns_ldf = to_lazy(returns)
 
@@ -47,13 +47,13 @@ def cagr(
     In this case, rf is assumed to be expressed in yearly (annualized) terms
 
     Args:
-        returns(pl.DataFrame | pl.LazyFrame): Returns dataframe or lazyframe
-        rf(float): Risk-free rate
-        compound(bool): Whether to compound the returns
-        periods(int): Number of periods in a year
+        returns: Returns dataframe or lazyframe
+        rf: Risk-free rate
+        compound: Whether to compound the returns
+        periods: Number of periods in a year
 
     Returns:
-        pl.DataFrame: CAGR%
+        CAGR%
     """
     returns_ldf = to_lazy(returns)
 
@@ -84,10 +84,10 @@ def max_drawdown(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> float | pl
     Maximum drawdown is the largest peak-to-trough decline in the cumulative returns.
 
     Args:
-        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
+        returns: Returns series or dataframe
 
     Returns:
-        float | pl.DataFrame: Maximum drawdown value(s)
+        Maximum drawdown value(s)
     """
     returns_ldf = to_lazy(returns)
 
@@ -128,13 +128,13 @@ def sharpe(
     The Sharpe ratio measures risk-adjusted return by dividing excess return by volatility.
 
     Args:
-        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
-        rf(float): Risk-free rate expressed as yearly (annualized) return
-        periods(int): Frequency of returns (252 for daily, 12 for monthly)
-        annualize(bool): Whether to annualize the Sharpe ratio
+        returns: Returns series or dataframe
+        rf: Risk-free rate expressed as yearly (annualized) return
+        periods: Frequency of returns (252 for daily, 12 for monthly)
+        annualize: Whether to annualize the Sharpe ratio
 
     Returns:
-        float | pl.DataFrame: Sharpe ratio value(s)
+        Sharpe ratio value(s)
     """
     returns_ldf = to_lazy(returns)
 
@@ -171,12 +171,12 @@ def volatility(
     Calculates the volatility (standard deviation) of returns.
 
     Args:
-        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
-        periods(int): Frequency of returns (252 for daily, 12 for monthly)
-        annualize(bool): Whether to annualize the volatility
+        returns: Returns series or dataframe
+        periods: Frequency of returns (252 for daily, 12 for monthly)
+        annualize: Whether to annualize the volatility
 
     Returns:
-        float | pl.DataFrame: Volatility value(s)
+        Volatility value(s)
     """
     returns_ldf = to_lazy(returns)
 
@@ -210,10 +210,10 @@ def to_drawdowns(
     Drawdowns shows the percentage decline from the previous peak at each point in time.
 
     Args:
-        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
+        returns: Returns series or dataframe
 
     Returns:
-        pl.Series | pl.DataFrame: Drawdowns with same structure as input
+        Drawdowns with same structure as input
     """
     returns_ldf = to_lazy(returns)
 

--- a/alphastats/stats.py
+++ b/alphastats/stats.py
@@ -1,0 +1,114 @@
+import polars as pl
+import polars.selectors as cs
+
+RETURNS_COLUMNS_SELECTOR = cs.numeric()
+DT_COLUMNS_SELECTOR = cs.temporal()
+
+
+def comp(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> float | pl.DataFrame:
+    """
+    Compute total compounded returns.
+
+    Args:
+        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
+
+    Returns:
+        float | pl.DataFrame: Compounded returns
+    """
+    if isinstance(returns, pl.Series):
+        returns = pl.LazyFrame(returns)
+
+    if isinstance(returns, pl.DataFrame):
+        returns = returns.lazy()
+
+    res = returns.select(_comp(RETURNS_COLUMNS_SELECTOR)).collect()
+
+    if _has_single_returns_column(returns):
+        return res.item()
+    else:
+        return res
+
+
+def _comp(expr: pl.Expr) -> pl.Expr:
+    return (expr + 1).product() - 1
+
+
+def cagr(
+    returns: pl.DataFrame | pl.LazyFrame,
+    rf: float = 0.0,
+    compound: bool = True,
+    periods: int = 252,
+) -> float | pl.DataFrame:
+    """
+    Calculates the communicative annualized growth return
+    (CAGR%) of access returns
+
+    If rf is non-zero, you must specify periods.
+    In this case, rf is assumed to be expressed in yearly (annualized) terms
+
+    Args:
+        returns(pl.DataFrame | pl.LazyFrame): Returns dataframe or lazyframe
+        rf(float): Risk-free rate
+        compound(bool): Whether to compound the returns
+        periods(int): Number of periods in a year
+
+    Returns:
+        float | pl.DataFrame: CAGR%
+    """
+
+    if isinstance(returns, pl.DataFrame):
+        returns = returns.lazy()
+
+    returns = _prepare_returns(returns, rf)
+    dt_col = _get_dt_column(returns)
+
+    n_years = (dt_col.last() - dt_col.first()).dt.total_days() / periods
+
+    if compound:
+        expr = _comp(RETURNS_COLUMNS_SELECTOR).add(1).pow(1 / n_years).sub(1)
+    else:
+        expr = (RETURNS_COLUMNS_SELECTOR).sum().add(1).pow(1 / n_years).sub(1)
+
+    return returns.with_columns(expr).collect()
+
+
+# def max_drawdown(): ...
+
+
+# def sharpe(): ...
+
+
+# def volatility(): ...
+
+
+# def greeks(): ...
+
+
+# def to_drawdown_series(): ...
+
+
+def _prepare_returns(returns: pl.LazyFrame, rf: float | pl.Series | None = None) -> pl.LazyFrame:
+    expr = (
+        pl.when((RETURNS_COLUMNS_SELECTOR).drop_nulls().is_between(0, 1))
+        .then(RETURNS_COLUMNS_SELECTOR)
+        .otherwise((RETURNS_COLUMNS_SELECTOR).pct_change())
+        .fill_null(0)
+    )
+
+    if rf:
+        return returns.with_columns(expr.sub(rf))
+
+    return returns.with_columns(expr)
+
+
+def _has_single_returns_column(returns: pl.LazyFrame) -> bool:
+    return len(cs.expand_selector(returns, cs.numeric())) == 1
+
+
+def _get_dt_column(returns: pl.LazyFrame) -> pl.Expr:
+    column_names = cs.expand_selector(returns, DT_COLUMNS_SELECTOR)
+
+    if len(column_names) != 1:
+        raise ValueError(f"Must have exactly one temporal column. Found {column_names}")
+
+    return DT_COLUMNS_SELECTOR

--- a/alphastats/stats.py
+++ b/alphastats/stats.py
@@ -40,7 +40,7 @@ def cagr(
     periods: int = 252,
 ) -> pl.DataFrame:
     """
-    Calculates the communicative annualized growth return
+    Calculates the Compound Annual Growth Rate
     (CAGR%) of access returns
 
     If rf is non-zero, you must specify periods.

--- a/alphastats/stats.py
+++ b/alphastats/stats.py
@@ -1,8 +1,18 @@
+from typing import overload
+
 import polars as pl
 import polars.selectors as cs
 
 RETURNS_COLUMNS_SELECTOR = cs.numeric()
 DT_COLUMNS_SELECTOR = cs.temporal()
+
+
+@overload
+def comp(returns: pl.Series) -> float: ...
+
+
+@overload
+def comp(returns: pl.DataFrame | pl.LazyFrame) -> pl.DataFrame: ...
 
 
 def comp(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> float | pl.DataFrame:
@@ -15,15 +25,11 @@ def comp(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> float | pl.DataFra
     Returns:
         float | pl.DataFrame: Compounded returns
     """
+    returns_ldf = _to_lazy(returns)
+
+    res = returns_ldf.select(_comp(RETURNS_COLUMNS_SELECTOR)).collect()
+
     if isinstance(returns, pl.Series):
-        returns = pl.LazyFrame(returns)
-
-    if isinstance(returns, pl.DataFrame):
-        returns = returns.lazy()
-
-    res = returns.select(_comp(RETURNS_COLUMNS_SELECTOR)).collect()
-
-    if _has_single_returns_column(returns):
         return res.item()
     else:
         return res
@@ -38,7 +44,7 @@ def cagr(
     rf: float = 0.0,
     compound: bool = True,
     periods: int = 252,
-) -> float | pl.DataFrame:
+) -> pl.DataFrame:
     """
     Calculates the communicative annualized growth return
     (CAGR%) of access returns
@@ -53,14 +59,10 @@ def cagr(
         periods(int): Number of periods in a year
 
     Returns:
-        float | pl.DataFrame: CAGR%
+        pl.DataFrame: CAGR%
     """
-
-    if isinstance(returns, pl.DataFrame):
-        returns = returns.lazy()
-
-    returns = _prepare_returns(returns, rf)
-    dt_col = _get_dt_column(returns)
+    returns_ldf = _prepare_returns(_to_lazy(returns), rf)
+    dt_col = _get_dt_column(returns_ldf)
 
     n_years = (dt_col.last() - dt_col.first()).dt.total_days() / periods
 
@@ -69,22 +71,169 @@ def cagr(
     else:
         expr = (RETURNS_COLUMNS_SELECTOR).sum().add(1).pow(1 / n_years).sub(1)
 
-    return returns.with_columns(expr).collect()
+    return returns_ldf.select(expr).collect()
 
 
-# def max_drawdown(): ...
+@overload
+def max_drawdown(returns: pl.Series) -> float: ...
 
 
-# def sharpe(): ...
+@overload
+def max_drawdown(returns: pl.DataFrame | pl.LazyFrame) -> pl.DataFrame: ...
 
 
-# def volatility(): ...
+def max_drawdown(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> float | pl.DataFrame:
+    """
+    Calculates the maximum drawdown of returns.
+
+    Maximum drawdown is the largest peak-to-trough decline in the cumulative returns.
+
+    Args:
+        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
+
+    Returns:
+        float | pl.DataFrame: Maximum drawdown value(s)
+    """
+    returns_ldf = _prepare_returns(_to_lazy(returns))
+
+    max_drawdown = _drawdowns(RETURNS_COLUMNS_SELECTOR).min()
+
+    res = returns_ldf.select(max_drawdown).collect()
+
+    if isinstance(returns, pl.Series):
+        return res.item()
+    else:
+        return res
 
 
-# def greeks(): ...
+@overload
+def sharpe(
+    returns: pl.Series, rf: float = 0.0, periods: int = 252, annualize: bool = True
+) -> float: ...
 
 
-# def to_drawdown_series(): ...
+@overload
+def sharpe(
+    returns: pl.DataFrame | pl.LazyFrame,
+    rf: float = 0.0,
+    periods: int = 252,
+    annualize: bool = True,
+) -> pl.DataFrame: ...
+
+
+def sharpe(
+    returns: pl.Series | pl.DataFrame | pl.LazyFrame,
+    rf: float | pl.Series | None = None,
+    periods: int = 252,
+    annualize: bool = True,
+) -> float | pl.DataFrame:
+    """
+    Calculates the Sharpe ratio of access returns.
+
+    The Sharpe ratio measures risk-adjusted return by dividing excess return by volatility.
+
+    Args:
+        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
+        rf(float): Risk-free rate expressed as yearly (annualized) return
+        periods(int): Frequency of returns (252 for daily, 12 for monthly)
+        annualize(bool): Whether to annualize the Sharpe ratio
+
+    Returns:
+        float | pl.DataFrame: Sharpe ratio value(s)
+    """
+    returns_ldf = _prepare_returns(_to_lazy(returns), rf)
+
+    sharpe = RETURNS_COLUMNS_SELECTOR.mean() / RETURNS_COLUMNS_SELECTOR.std(ddof=1)
+
+    if annualize:
+        sharpe = sharpe * (periods**0.5)
+
+    res = returns_ldf.select(sharpe).collect()
+
+    if isinstance(returns, pl.Series):
+        return res.item()
+    else:
+        return res
+
+
+@overload
+def volatility(returns: pl.Series, periods: int = 252, annualize: bool = True) -> float: ...
+
+
+@overload
+def volatility(
+    returns: pl.DataFrame | pl.LazyFrame, periods: int = 252, annualize: bool = True
+) -> pl.DataFrame: ...
+
+
+def volatility(
+    returns: pl.Series | pl.DataFrame | pl.LazyFrame,
+    periods: int = 252,
+    annualize: bool = True,
+) -> float | pl.DataFrame:
+    """
+    Calculates the volatility (standard deviation) of returns.
+
+    Args:
+        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
+        periods(int): Frequency of returns (252 for daily, 12 for monthly)
+        annualize(bool): Whether to annualize the volatility
+
+    Returns:
+        float | pl.DataFrame: Volatility value(s)
+    """
+    returns_ldf = _prepare_returns(_to_lazy(returns))
+
+    std_expr = RETURNS_COLUMNS_SELECTOR.std(ddof=1)
+
+    if annualize:
+        std_expr = std_expr * (periods**0.5)
+
+    res = returns_ldf.select(std_expr).collect()
+
+    if isinstance(returns, pl.Series):
+        return res.item()
+    else:
+        return res
+
+
+@overload
+def to_drawdowns(returns: pl.Series) -> pl.Series: ...
+
+
+@overload
+def to_drawdowns(returns: pl.DataFrame | pl.LazyFrame) -> pl.DataFrame: ...
+
+
+def to_drawdowns(
+    returns: pl.Series | pl.DataFrame | pl.LazyFrame,
+) -> pl.Series | pl.DataFrame:
+    """
+    Convert returns to drawdowns.
+
+    Drawdowns shows the percentage decline from the previous peak at each point in time.
+
+    Args:
+        returns(pl.Series | pl.DataFrame | pl.LazyFrame): Returns series or dataframe
+
+    Returns:
+        pl.Series | pl.DataFrame: Drawdowns with same structure as input
+    """
+    returns_ldf = _prepare_returns(_to_lazy(returns))
+
+    res = returns_ldf.with_columns(_drawdowns(RETURNS_COLUMNS_SELECTOR)).collect()
+
+    if isinstance(returns, pl.Series):
+        return res.to_series()
+    else:
+        return res
+
+
+def _drawdowns(expr: pl.Expr) -> pl.Expr:
+    wealth_index = (expr + 1).cum_prod()
+    running_max_wealth_index = wealth_index.cum_max()
+    drawdowns = (wealth_index / running_max_wealth_index) - 1
+    return drawdowns.clip(lower_bound=None, upper_bound=0)
 
 
 def _prepare_returns(returns: pl.LazyFrame, rf: float | pl.Series | None = None) -> pl.LazyFrame:
@@ -101,10 +250,6 @@ def _prepare_returns(returns: pl.LazyFrame, rf: float | pl.Series | None = None)
     return returns.with_columns(expr)
 
 
-def _has_single_returns_column(returns: pl.LazyFrame) -> bool:
-    return len(cs.expand_selector(returns, cs.numeric())) == 1
-
-
 def _get_dt_column(returns: pl.LazyFrame) -> pl.Expr:
     column_names = cs.expand_selector(returns, DT_COLUMNS_SELECTOR)
 
@@ -112,3 +257,15 @@ def _get_dt_column(returns: pl.LazyFrame) -> pl.Expr:
         raise ValueError(f"Must have exactly one temporal column. Found {column_names}")
 
     return DT_COLUMNS_SELECTOR
+
+
+def _to_lazy(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> pl.LazyFrame:
+    match returns:
+        case pl.Series():
+            ldf = pl.LazyFrame(returns)
+        case pl.DataFrame():
+            ldf = returns.lazy()
+        case pl.LazyFrame():
+            ldf = returns
+
+    return ldf.fill_nan(None)

--- a/alphastats/stats.py
+++ b/alphastats/stats.py
@@ -256,7 +256,7 @@ def _get_dt_column(returns: pl.LazyFrame) -> pl.Expr:
     if len(column_names) != 1:
         raise ValueError(f"Must have exactly one temporal column. Found {column_names}")
 
-    return DT_COLUMNS_SELECTOR
+    return pl.col(column_names[0])
 
 
 def _to_lazy(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> pl.LazyFrame:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,12 @@ dependencies = ["polars>=1.0.0,<2"]
 
 [dependency-groups]
 dev = [
+    "inline-snapshot>=0.23.2",
     "mypy==1.15.0",
- "pre-commit>=4.2.0",
- "pytest>=8.3.5",
- "pytest-asyncio>=1.0.0",
- "ruff==0.11.2",
+    "pre-commit>=4.2.0",
+    "pytest>=8.3.5",
+    "pytest-asyncio>=1.0.0",
+    "ruff==0.11.2",
 ]
 
 [build-system]
@@ -66,3 +67,6 @@ preview = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.inline-snapshot]
+format-command = "ruff format --stdin-filename {filename}"

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,3 +1,4 @@
+import datetime
 import math
 from datetime import date
 
@@ -372,9 +373,16 @@ class TestToDrawdowns:
     def test_to_drawdowns_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
         """Test drawdowns calculation for dataframe."""
         result = stats.to_drawdowns(simple_returns_df)
-        expected_dict = result.select(pl.exclude("date")).to_dict(as_series=False)
+        expected_dict = result.to_dict(as_series=False)
         assert expected_dict == snapshot(
             {
+                "date": [
+                    datetime.date(2023, 1, 1),
+                    datetime.date(2023, 1, 2),
+                    datetime.date(2023, 1, 3),
+                    datetime.date(2023, 1, 4),
+                    datetime.date(2023, 1, 5),
+                ],
                 "asset_a": [0.0, -0.020000000000000018, 0.0, -0.01000000000000012, 0.0],
                 "asset_b": [
                     0.0,

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,407 @@
+import math
+from collections.abc import Generator
+from datetime import date
+
+import polars as pl
+import pytest
+from inline_snapshot import snapshot
+
+from alphastats import stats
+
+
+@pytest.fixture(autouse=True)
+def set_float_precision() -> Generator[None, None, None]:
+    with pl.Config(set_float_precision=6):
+        yield
+
+
+@pytest.fixture
+def simple_returns_series() -> pl.Series:
+    """Simple returns series for basic testing."""
+    return pl.Series("returns", [0.01, -0.02, 0.03, -0.01, 0.02])
+
+
+@pytest.fixture
+def simple_returns_df() -> pl.DataFrame:
+    """Simple returns dataframe with multiple assets."""
+    return pl.DataFrame(
+        {
+            "date": [date(2023, 1, i) for i in range(1, 6)],
+            "asset_a": [0.01, -0.02, 0.03, -0.01, 0.02],
+            "asset_b": [0.02, -0.01, 0.01, 0.03, -0.02],
+        }
+    )
+
+
+@pytest.fixture
+def returns_with_nulls() -> pl.Series:
+    """Returns series with null values."""
+    return pl.Series("returns", [0.01, None, 0.03, -0.01, None])
+
+
+@pytest.fixture
+def extreme_returns() -> pl.Series:
+    """Returns series with extreme values for edge case testing."""
+    return pl.Series("returns", [0.5, -0.8, 1.2, -0.9, 0.3])
+
+
+@pytest.fixture
+def empty_returns() -> pl.Series:
+    """Returns series with empty values for edge case testing."""
+    return pl.Series("returns", [])
+
+
+class TestComp:
+    """Test cases for the comp (compound returns) function."""
+
+    @pytest.mark.parametrize(
+        "returns_fixture,expected_type",
+        [
+            ("simple_returns_series", float),
+            ("simple_returns_df", pl.DataFrame),
+        ],
+    )
+    def test_comp_return_types(
+        self, returns_fixture: str, expected_type: type, request: pytest.FixtureRequest
+    ) -> None:
+        """Test that comp returns correct types for different inputs."""
+        returns_data = request.getfixturevalue(returns_fixture)
+        if returns_fixture == "simple_returns_df":
+            # Test both DataFrame and LazyFrame
+            result_df = stats.comp(returns_data)
+            assert isinstance(result_df, expected_type)
+
+            result_lazy = stats.comp(returns_data.lazy())
+            assert isinstance(result_lazy, expected_type)
+        else:
+            result = stats.comp(returns_data)
+            assert isinstance(result, expected_type)
+
+    def test_comp_series_calculation(self, simple_returns_series: pl.Series) -> None:
+        """Test compound returns calculation for series."""
+        result = stats.comp(simple_returns_series)
+        assert result == snapshot(0.02948504120000006)
+
+    def test_comp_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
+        """Test compound returns calculation for dataframe."""
+        result = stats.comp(simple_returns_df)
+        assert result.to_dict(as_series=False) == snapshot(
+            {"asset_a": [0.02948504120000006], "asset_b": [0.02948504120000006]}
+        )
+
+    def test_comp_with_nulls(self, returns_with_nulls: pl.Series) -> None:
+        """Test compound returns with null values."""
+        result = stats.comp(returns_with_nulls)
+        assert result == snapshot(0.029897000000000062)
+
+    def test_comp_extreme_values(self, extreme_returns: pl.Series) -> None:
+        """Test compound returns with extreme values."""
+        result = stats.comp(extreme_returns)
+        assert result == snapshot(-0.9142)
+
+    def test_comp_empty_data(self, empty_returns: pl.Series) -> None:
+        """Test comp with empty data."""
+        with pytest.raises(
+            ValueError, match=r"can only call `.item\(\)` if the dataframe is of shape \(1, 1\)"
+        ):
+            stats.comp(empty_returns)
+
+    def test_comp_single_value(self) -> None:
+        """Test comp with single value."""
+        single_series = pl.Series("returns", [0.05])
+        result = stats.comp(single_series)
+        assert result == snapshot(0.050000000000000044)
+
+    def test_comp_all_zeros(self) -> None:
+        """Test comp with all zero returns."""
+        zero_series = pl.Series("returns", [0.0, 0.0, 0.0, 0.0])
+        result = stats.comp(zero_series)
+        assert result == snapshot(0.0)
+
+
+class TestCagr:
+    """Test cases for the CAGR (Compound Annual Growth Rate) function."""
+
+    def test_cagr_basic_calculation(self, simple_returns_df: pl.DataFrame) -> None:
+        """Test basic CAGR calculation."""
+        result = stats.cagr(simple_returns_df, periods=252)
+        assert result.to_dict(as_series=False) == snapshot(
+            {"asset_a": [-0.9999999996618938], "asset_b": [-1.0]}
+        )
+
+    def test_cagr_with_risk_free_rate(self, simple_returns_df: pl.DataFrame) -> None:
+        """Test CAGR calculation with risk-free rate."""
+        result = stats.cagr(simple_returns_df, rf=0.02, periods=252)
+        assert result.to_dict(as_series=False) == snapshot(
+            {"asset_a": [-0.999999999411115], "asset_b": [-1.0]}
+        )
+
+    def test_cagr_non_compound(self, simple_returns_df: pl.DataFrame) -> None:
+        """Test CAGR calculation without compounding."""
+        result = stats.cagr(simple_returns_df, compound=False, periods=252)
+        assert result.to_dict(as_series=False) == snapshot(
+            {"asset_a": [-2.782176533738531e32], "asset_b": [-2.43521261277413e20]}
+        )
+
+    def test_cagr_different_periods(self, simple_returns_df: pl.DataFrame) -> None:
+        """Test CAGR calculation with different period frequencies."""
+        result = stats.cagr(simple_returns_df, periods=12)  # Monthly
+        assert result.to_dict(as_series=False) == snapshot(
+            {"asset_a": [-0.6460005937649241], "asset_b": [-0.9557500742206155]}
+        )
+
+    def test_cagr_extreme_values(self) -> None:
+        """Test CAGR with extreme values."""
+        extreme_df = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "asset": [0.5, -0.8, 1.2, -0.9, 0.3],
+            }
+        )
+        result = stats.cagr(extreme_df, periods=252)
+        assert result.to_dict(as_series=False) == snapshot({"asset": [-2.261248737261588e34]})
+
+
+class TestMaxDrawdown:
+    """Test cases for the max_drawdown function."""
+
+    @pytest.mark.parametrize(
+        "returns_fixture,expected_type",
+        [
+            ("simple_returns_series", float),
+            ("simple_returns_df", pl.DataFrame),
+        ],
+    )
+    def test_max_drawdown_return_types(
+        self, returns_fixture: str, expected_type: type, request: pytest.FixtureRequest
+    ) -> None:
+        """Test that max_drawdown returns correct types for different inputs."""
+        returns_data = request.getfixturevalue(returns_fixture)
+        if returns_fixture == "simple_returns_df":
+            # Test both DataFrame and LazyFrame
+            result_df = stats.max_drawdown(returns_data)
+            assert isinstance(result_df, expected_type)
+
+            result_lazy = stats.max_drawdown(returns_data.lazy())
+            assert isinstance(result_lazy, expected_type)
+        else:
+            result = stats.max_drawdown(returns_data)
+            assert isinstance(result, expected_type)
+
+    def test_max_drawdown_series_calculation(self, simple_returns_series: pl.Series) -> None:
+        """Test maximum drawdown calculation for series."""
+        result = stats.max_drawdown(simple_returns_series)
+        assert result == snapshot(-3.06)
+
+    def test_max_drawdown_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
+        """Test maximum drawdown calculation for dataframe."""
+        result = stats.max_drawdown(simple_returns_df)
+        assert result.to_dict(as_series=False) == snapshot(
+            {"asset_a": [-3.06], "asset_b": [-1.5201500000000001]}
+        )
+
+    def test_max_drawdown_extreme_values(self, extreme_returns: pl.Series) -> None:
+        """Test maximum drawdown with extreme values."""
+        result = stats.max_drawdown(extreme_returns)
+        assert result == snapshot(-2.6000000000000005)
+
+    def test_max_drawdown_single_value(self) -> None:
+        """Test max_drawdown with single value."""
+        single_series = pl.Series("returns", [0.05])
+        result = stats.max_drawdown(single_series)
+        assert result == snapshot(0.0)
+
+    def test_max_drawdown_all_zeros(self) -> None:
+        """Test max_drawdown with all zero returns."""
+        zero_series = pl.Series("returns", [0.0, 0.0, 0.0, 0.0])
+        result = stats.max_drawdown(zero_series)
+        assert result == snapshot(0.0)
+
+
+class TestSharpe:
+    """Test cases for the Sharpe ratio function."""
+
+    @pytest.mark.parametrize(
+        "returns_fixture,expected_type",
+        [
+            ("simple_returns_series", float),
+            ("simple_returns_df", pl.DataFrame),
+        ],
+    )
+    def test_sharpe_return_types(
+        self, returns_fixture: str, expected_type: type, request: pytest.FixtureRequest
+    ) -> None:
+        """Test that sharpe returns correct types for different inputs."""
+        returns_data = request.getfixturevalue(returns_fixture)
+        if returns_fixture == "simple_returns_df":
+            # Test both DataFrame and LazyFrame
+            result_df = stats.sharpe(returns_data)
+            assert isinstance(result_df, expected_type)
+
+            result_lazy = stats.sharpe(returns_data.lazy())
+            assert isinstance(result_lazy, expected_type)
+        else:
+            result = stats.sharpe(returns_data)
+            assert isinstance(result, expected_type)
+
+    def test_sharpe_series_calculation(self, simple_returns_series: pl.Series) -> None:
+        """Test Sharpe ratio calculation for series."""
+        result = stats.sharpe(simple_returns_series)
+        assert result == snapshot(-10.164280273197951)
+
+    def test_sharpe_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
+        """Test Sharpe ratio calculation for dataframe."""
+        result = stats.sharpe(simple_returns_df)
+        assert result.to_dict(as_series=False) == snapshot(
+            {"asset_a": [-10.164280273197951], "asset_b": [-11.20600940533624]}
+        )
+
+    def test_sharpe_with_risk_free_rate(self, simple_returns_series: pl.Series) -> None:
+        """Test Sharpe ratio with risk-free rate."""
+        result = stats.sharpe(simple_returns_series, rf=0.02)
+        assert result == snapshot(-10.402133945737683)
+
+    def test_sharpe_non_annualized(self, simple_returns_series: pl.Series) -> None:
+        """Test Sharpe ratio without annualization."""
+        result = stats.sharpe(simple_returns_series, annualize=False)
+        assert result == snapshot(-0.640289472829558)
+
+    def test_sharpe_different_periods(self, simple_returns_series: pl.Series) -> None:
+        """Test Sharpe ratio with different period frequencies."""
+        result = stats.sharpe(simple_returns_series, periods=12)  # Monthly
+        assert result == snapshot(-2.218027796984573)
+
+    def test_sharpe_extreme_values(self, extreme_returns: pl.Series) -> None:
+        """Test Sharpe ratio with extreme values."""
+        result = stats.sharpe(extreme_returns)
+        assert result == snapshot(-12.740483884391793)
+
+    def test_sharpe_all_zeros(self) -> None:
+        """Test Sharpe ratio with all zero returns."""
+        zero_series = pl.Series("returns", [0.0, 0.0, 0.0, 0.0])
+        result = stats.sharpe(zero_series)
+        assert math.isnan(result)
+
+
+class TestVolatility:
+    """Test cases for the volatility function."""
+
+    @pytest.mark.parametrize(
+        "returns_fixture,expected_type",
+        [
+            ("simple_returns_series", float),
+            ("simple_returns_df", pl.DataFrame),
+        ],
+    )
+    def test_volatility_return_types(
+        self, returns_fixture: str, expected_type: type, request: pytest.FixtureRequest
+    ) -> None:
+        """Test that volatility returns correct types for different inputs."""
+        returns_data = request.getfixturevalue(returns_fixture)
+        if returns_fixture == "simple_returns_df":
+            # Test both DataFrame and LazyFrame
+            result_df = stats.volatility(returns_data)
+            assert isinstance(result_df, expected_type)
+
+            result_lazy = stats.volatility(returns_data.lazy())
+            assert isinstance(result_lazy, expected_type)
+        else:
+            result = stats.volatility(returns_data)
+            assert isinstance(result, expected_type)
+
+    def test_volatility_series_calculation(self, simple_returns_series: pl.Series) -> None:
+        """Test volatility calculation for series."""
+        result = stats.volatility(simple_returns_series)
+        assert result == snapshot(21.189498342339302)
+
+    def test_volatility_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
+        """Test volatility calculation for dataframe."""
+        result = stats.volatility(simple_returns_df)
+        assert result.to_dict(as_series=False) == snapshot(
+            {"asset_a": [21.189498342339302], "asset_b": [13.972502996957992]}
+        )
+
+    def test_volatility_non_annualized(self, simple_returns_series: pl.Series) -> None:
+        """Test volatility without annualization."""
+        result = stats.volatility(simple_returns_series, annualize=False)
+        assert result == snapshot(1.3348129290486948)
+
+    def test_volatility_different_periods(self, simple_returns_series: pl.Series) -> None:
+        """Test volatility with different period frequencies."""
+        result = stats.volatility(simple_returns_series, periods=12)  # Monthly
+        assert result == snapshot(4.62392762342434)
+
+    def test_volatility_extreme_values(self, extreme_returns: pl.Series) -> None:
+        """Test volatility with extreme values."""
+        result = stats.volatility(extreme_returns)
+        assert result == snapshot(23.93315691671285)
+
+    def test_volatility_all_zeros(self) -> None:
+        """Test volatility with all zero returns."""
+        zero_series = pl.Series("returns", [0.0, 0.0, 0.0, 0.0])
+        result = stats.volatility(zero_series)
+        assert result == snapshot(0.0)
+
+
+class TestToDrawdowns:
+    """Test cases for the to_drawdowns function."""
+
+    @pytest.mark.parametrize(
+        "returns_fixture,expected_type",
+        [
+            ("simple_returns_series", pl.Series),
+            ("simple_returns_df", pl.DataFrame),
+        ],
+    )
+    def test_to_drawdowns_return_types(
+        self, returns_fixture: str, expected_type: type, request: pytest.FixtureRequest
+    ) -> None:
+        """Test that to_drawdowns returns correct types for different inputs."""
+        returns_data = request.getfixturevalue(returns_fixture)
+        if returns_fixture == "simple_returns_df":
+            # Test both DataFrame and LazyFrame
+            result_df = stats.to_drawdowns(returns_data)
+            assert isinstance(result_df, expected_type)
+
+            result_lazy = stats.to_drawdowns(returns_data.lazy())
+            assert isinstance(result_lazy, expected_type)
+        else:
+            result = stats.to_drawdowns(returns_data)
+            assert isinstance(result, expected_type)
+
+    def test_to_drawdowns_series_calculation(self, simple_returns_series: pl.Series) -> None:
+        """Test drawdowns calculation for series."""
+        result = stats.to_drawdowns(simple_returns_series)
+        assert result.to_list() == snapshot(
+            [0.0, -3.0, -3.06, -0.313333333333333, -0.29959999999999964]
+        )
+
+    def test_to_drawdowns_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
+        """Test drawdowns calculation for dataframe."""
+        result = stats.to_drawdowns(simple_returns_df)
+        expected_dict = result.select(pl.exclude("date")).to_dict(as_series=False)
+        assert expected_dict == snapshot(
+            {
+                "asset_a": [0.0, -3.0, -3.06, -0.313333333333333, -0.29959999999999964],
+                "asset_b": [0.0, -1.5, -1.505, -1.5201500000000001, -0.6532333333333333],
+            }
+        )
+
+    def test_to_drawdowns_extreme_values(self, extreme_returns: pl.Series) -> None:
+        """Test drawdowns with extreme values."""
+        result = stats.to_drawdowns(extreme_returns)
+        assert result.to_list() == snapshot(
+            [0.0, -2.6000000000000005, 0.0, -1.7500000000000002, -1.9750000000000003]
+        )
+
+    def test_to_drawdowns_all_zeros(self) -> None:
+        """Test drawdowns with all zero returns."""
+        zero_series = pl.Series("returns", [0.0, 0.0, 0.0, 0.0])
+        result = stats.to_drawdowns(zero_series)
+        assert result.to_list() == snapshot([0.0, 0.0, 0.0, 0.0])
+
+    def test_to_drawdowns_single_value(self) -> None:
+        """Test drawdowns with single value."""
+        single_series = pl.Series("returns", [0.05])
+        result = stats.to_drawdowns(single_series)
+        assert result.to_list() == snapshot([0.0])

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,5 +1,4 @@
 import math
-from collections.abc import Generator
 from datetime import date
 
 import polars as pl
@@ -7,12 +6,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from alphastats import stats
-
-
-@pytest.fixture(autouse=True)
-def set_float_precision() -> Generator[None, None, None]:
-    with pl.Config(set_float_precision=6):
-        yield
 
 
 @pytest.fixture
@@ -126,28 +119,28 @@ class TestCagr:
         """Test basic CAGR calculation."""
         result = stats.cagr(simple_returns_df, periods=252)
         assert result.to_dict(as_series=False) == snapshot(
-            {"asset_a": [-0.9999999996618938], "asset_b": [-1.0]}
+            {"asset_a": [5.238246821747209], "asset_b": [5.238246821747209]}
         )
 
     def test_cagr_with_risk_free_rate(self, simple_returns_df: pl.DataFrame) -> None:
         """Test CAGR calculation with risk-free rate."""
-        result = stats.cagr(simple_returns_df, rf=0.02, periods=252)
+        result = stats.cagr(simple_returns_df, rf=0.002, periods=252)
         assert result.to_dict(as_series=False) == snapshot(
-            {"asset_a": [-0.999999999411115], "asset_b": [-1.0]}
+            {"asset_a": [2.3321544328343586], "asset_b": [2.3321544328344044]}
         )
 
     def test_cagr_non_compound(self, simple_returns_df: pl.DataFrame) -> None:
         """Test CAGR calculation without compounding."""
         result = stats.cagr(simple_returns_df, compound=False, periods=252)
         assert result.to_dict(as_series=False) == snapshot(
-            {"asset_a": [-2.782176533738531e32], "asset_b": [-2.43521261277413e20]}
+            {"asset_a": [5.437913785074596], "asset_b": [5.437913785074596]}
         )
 
     def test_cagr_different_periods(self, simple_returns_df: pl.DataFrame) -> None:
         """Test CAGR calculation with different period frequencies."""
         result = stats.cagr(simple_returns_df, periods=12)  # Monthly
         assert result.to_dict(as_series=False) == snapshot(
-            {"asset_a": [-0.6460005937649241], "asset_b": [-0.9557500742206155]}
+            {"asset_a": [0.09108885990481008], "asset_b": [0.09108885990481008]}
         )
 
     def test_cagr_extreme_values(self) -> None:
@@ -159,7 +152,7 @@ class TestCagr:
             }
         )
         result = stats.cagr(extreme_df, periods=252)
-        assert result.to_dict(as_series=False) == snapshot({"asset": [-2.261248737261588e34]})
+        assert result.to_dict(as_series=False) == snapshot({"asset": [-1.0]})
 
 
 class TestMaxDrawdown:
@@ -191,19 +184,19 @@ class TestMaxDrawdown:
     def test_max_drawdown_series_calculation(self, simple_returns_series: pl.Series) -> None:
         """Test maximum drawdown calculation for series."""
         result = stats.max_drawdown(simple_returns_series)
-        assert result == snapshot(-3.06)
+        assert result == snapshot(-0.020000000000000018)
 
     def test_max_drawdown_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
         """Test maximum drawdown calculation for dataframe."""
         result = stats.max_drawdown(simple_returns_df)
         assert result.to_dict(as_series=False) == snapshot(
-            {"asset_a": [-3.06], "asset_b": [-1.5201500000000001]}
+            {"asset_a": [-0.020000000000000018], "asset_b": [-0.020000000000000018]}
         )
 
     def test_max_drawdown_extreme_values(self, extreme_returns: pl.Series) -> None:
         """Test maximum drawdown with extreme values."""
         result = stats.max_drawdown(extreme_returns)
-        assert result == snapshot(-2.6000000000000005)
+        assert result == snapshot(-0.956)
 
     def test_max_drawdown_single_value(self) -> None:
         """Test max_drawdown with single value."""
@@ -247,34 +240,34 @@ class TestSharpe:
     def test_sharpe_series_calculation(self, simple_returns_series: pl.Series) -> None:
         """Test Sharpe ratio calculation for series."""
         result = stats.sharpe(simple_returns_series)
-        assert result == snapshot(-10.164280273197951)
+        assert result == snapshot(4.593220484431882)
 
     def test_sharpe_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
         """Test Sharpe ratio calculation for dataframe."""
         result = stats.sharpe(simple_returns_df)
         assert result.to_dict(as_series=False) == snapshot(
-            {"asset_a": [-10.164280273197951], "asset_b": [-11.20600940533624]}
+            {"asset_a": [4.593220484431882], "asset_b": [4.593220484431882]}
         )
 
     def test_sharpe_with_risk_free_rate(self, simple_returns_series: pl.Series) -> None:
         """Test Sharpe ratio with risk-free rate."""
-        result = stats.sharpe(simple_returns_series, rf=0.02)
-        assert result == snapshot(-10.402133945737683)
+        result = stats.sharpe(simple_returns_series, rf=0.002)
+        assert result == snapshot(3.062146989621255)
 
     def test_sharpe_non_annualized(self, simple_returns_series: pl.Series) -> None:
         """Test Sharpe ratio without annualization."""
         result = stats.sharpe(simple_returns_series, annualize=False)
-        assert result == snapshot(-0.640289472829558)
+        assert result == snapshot(0.28934569330224724)
 
     def test_sharpe_different_periods(self, simple_returns_series: pl.Series) -> None:
         """Test Sharpe ratio with different period frequencies."""
         result = stats.sharpe(simple_returns_series, periods=12)  # Monthly
-        assert result == snapshot(-2.218027796984573)
+        assert result == snapshot(1.002322883501468)
 
     def test_sharpe_extreme_values(self, extreme_returns: pl.Series) -> None:
         """Test Sharpe ratio with extreme values."""
         result = stats.sharpe(extreme_returns)
-        assert result == snapshot(-12.740483884391793)
+        assert result == snapshot(1.0629032821934614)
 
     def test_sharpe_all_zeros(self) -> None:
         """Test Sharpe ratio with all zero returns."""
@@ -312,29 +305,29 @@ class TestVolatility:
     def test_volatility_series_calculation(self, simple_returns_series: pl.Series) -> None:
         """Test volatility calculation for series."""
         result = stats.volatility(simple_returns_series)
-        assert result == snapshot(21.189498342339302)
+        assert result == snapshot(0.3291808013842849)
 
     def test_volatility_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
         """Test volatility calculation for dataframe."""
         result = stats.volatility(simple_returns_df)
         assert result.to_dict(as_series=False) == snapshot(
-            {"asset_a": [21.189498342339302], "asset_b": [13.972502996957992]}
+            {"asset_a": [0.3291808013842849], "asset_b": [0.3291808013842849]}
         )
 
     def test_volatility_non_annualized(self, simple_returns_series: pl.Series) -> None:
         """Test volatility without annualization."""
         result = stats.volatility(simple_returns_series, annualize=False)
-        assert result == snapshot(1.3348129290486948)
+        assert result == snapshot(0.020736441353327723)
 
     def test_volatility_different_periods(self, simple_returns_series: pl.Series) -> None:
         """Test volatility with different period frequencies."""
         result = stats.volatility(simple_returns_series, periods=12)  # Monthly
-        assert result == snapshot(4.62392762342434)
+        assert result == snapshot(0.07183313998427189)
 
     def test_volatility_extreme_values(self, extreme_returns: pl.Series) -> None:
         """Test volatility with extreme values."""
         result = stats.volatility(extreme_returns)
-        assert result == snapshot(23.93315691671285)
+        assert result == snapshot(14.225188926689164)
 
     def test_volatility_all_zeros(self) -> None:
         """Test volatility with all zero returns."""
@@ -373,7 +366,7 @@ class TestToDrawdowns:
         """Test drawdowns calculation for series."""
         result = stats.to_drawdowns(simple_returns_series)
         assert result.to_list() == snapshot(
-            [0.0, -3.0, -3.06, -0.313333333333333, -0.29959999999999964]
+            [0.0, -0.020000000000000018, 0.0, -0.01000000000000012, 0.0]
         )
 
     def test_to_drawdowns_dataframe_calculation(self, simple_returns_df: pl.DataFrame) -> None:
@@ -382,17 +375,21 @@ class TestToDrawdowns:
         expected_dict = result.select(pl.exclude("date")).to_dict(as_series=False)
         assert expected_dict == snapshot(
             {
-                "asset_a": [0.0, -3.0, -3.06, -0.313333333333333, -0.29959999999999964],
-                "asset_b": [0.0, -1.5, -1.505, -1.5201500000000001, -0.6532333333333333],
+                "asset_a": [0.0, -0.020000000000000018, 0.0, -0.01000000000000012, 0.0],
+                "asset_b": [
+                    0.0,
+                    -0.010000000000000009,
+                    -0.00010000000000010001,
+                    0.0,
+                    -0.020000000000000018,
+                ],
             }
         )
 
     def test_to_drawdowns_extreme_values(self, extreme_returns: pl.Series) -> None:
         """Test drawdowns with extreme values."""
         result = stats.to_drawdowns(extreme_returns)
-        assert result.to_list() == snapshot(
-            [0.0, -2.6000000000000005, 0.0, -1.7500000000000002, -1.9750000000000003]
-        )
+        assert result.to_list() == snapshot([0.0, -0.8, -0.56, -0.956, -0.9428])
 
     def test_to_drawdowns_all_zeros(self) -> None:
         """Test drawdowns with all zero returns."""

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "inline-snapshot" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -24,11 +25,21 @@ requires-dist = [{ name = "polars", specifier = ">=1.0.0,<2" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "inline-snapshot", specifier = ">=0.23.2" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "ruff", specifier = "==0.11.2" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978, upload-time = "2024-11-30T04:30:14.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918, upload-time = "2024-11-30T04:30:10.946Z" },
 ]
 
 [[package]]
@@ -59,6 +70,15 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693, upload-time = "2025-01-22T15:41:29.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702, upload-time = "2025-01-22T15:41:25.929Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -83,6 +103,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "inline-snapshot"
+version = "0.23.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/51/230163dedc58218b02421c6cc87aaf797451e244ed7756c0283471927ae2/inline_snapshot-0.23.2.tar.gz", hash = "sha256:440060e090db0da98bd1dea5d9c346291a0c7388213ff9437411ed59885a956d", size = 260704, upload-time = "2025-05-28T11:00:47.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/c8/ba2f735dd8a7fdd7199a92a9efdfc23e12d7a835b086bbba22a9a298debe/inline_snapshot-0.23.2-py3-none-any.whl", hash = "sha256:b6e32541d0ba116f5a0f4cca944729fa1095f6c08e190d531ab339b624654576", size = 50635, upload-time = "2025-05-28T11:00:45.976Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -192,6 +248,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -251,6 +316,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**리뷰어가 작업내용을 이해하기 쉽도록 아래내용을 상세히 작성해주세요.**

## Changes

- 일부 stats 지표를 추가하였습니다. (comp, cagr, max_drawdown, sharpe, volatility, to_drawdowns)
- 이번 PR에서 전반적인 인터페이스에 관한 리뷰를 받고, 나머지 지표들을 추가할 예정입니다.

### Interfaces

함수 시그니처에 관한 규칙은 다음과 같습니다.

- 인자로 Series를 받는 경우: float 혹은 Series를 리턴(함수 종류에 따라 상이)
- 인자로 Frame을 받는 경우: Frame을 항상 리턴합니다. Frame의 aggregate 메서드를 호출해도 Series가 아닌 Frame을 반환하는 polars의 인터페이스를 따랐습니다(ex. DataFrame.sum()은 1-row DataFrame을 리턴함).

입력 데이터의 스키마에 관한 규약은 다음과 같습니다.
- Series를 입력하는 경우, 수익률 벡터를 데이터로 담고 있어야 함
- DataFrame을 입력하는 경우,
  - 최소 하나 이상의 수익률 벡터 컬럼을 포함해야 함
  - 연산에 날짜 index가 필요한 일부 지표의 경우, 시간 관련(temporal) 컬럼을 포함해야 함

## Test

> **💡** _진행한 테스트에 대해서 구체적으로 작성해주세요._

- 지표별 테스트케이스를 추가하였습니다.
