### PR TITLE
feat: greeks stat 추가

### DIFF
--- a/alphastats/_utils.py
+++ b/alphastats/_utils.py
@@ -1,17 +1,25 @@
 import polars as pl
 import polars.selectors as cs
 
+from alphastats.exceptions import (
+    AmbiguousBenchmarkReturnsError,
+    MultipleTemporalColumnsError,
+    NoReturnColumnError,
+)
+
 RETURNS_COLUMNS_SELECTOR = cs.numeric()
-DT_COLUMNS_SELECTOR = cs.temporal()
+TEMPORAL_COLUMNS_SELECTOR = cs.temporal()
+
+BENCHMARK_RETURNS = "_benchmark_returns"
 
 
-def get_dt_column(returns: pl.LazyFrame) -> pl.Expr:
-    column_names = cs.expand_selector(returns, DT_COLUMNS_SELECTOR)
+def get_temporal_column(returns: pl.LazyFrame) -> pl.Expr | None:
+    column_names = cs.expand_selector(returns, TEMPORAL_COLUMNS_SELECTOR)
 
-    if len(column_names) != 1:
-        raise ValueError(f"Must have exactly one temporal column. Found {column_names}")
+    if len(column_names) > 1:
+        raise MultipleTemporalColumnsError(column_names)
 
-    return pl.col(column_names[0])
+    return pl.col(column_names[0]) if column_names else None
 
 
 def to_lazy(returns: pl.Series | pl.DataFrame | pl.LazyFrame) -> pl.LazyFrame:
@@ -31,3 +39,19 @@ def to_excess_returns(expr: pl.Expr, rf: float | pl.Series | None) -> pl.Expr:
         return expr
 
     return expr.sub(rf)
+
+
+def prepare_benchmark(benchmark: pl.LazyFrame) -> pl.LazyFrame:
+    column_names = cs.expand_selector(benchmark, RETURNS_COLUMNS_SELECTOR)
+    match len(column_names):
+        case 0:
+            raise NoReturnColumnError
+        case 1:
+            return_col = pl.col(column_names[0])
+        case _:
+            raise AmbiguousBenchmarkReturnsError(column_names)
+
+    if (temporal_col := get_temporal_column(benchmark)) is not None:
+        return benchmark.select(temporal_col, return_col.alias(BENCHMARK_RETURNS))
+    else:
+        return benchmark.select(return_col.alias(BENCHMARK_RETURNS))

--- a/alphastats/_utils.py
+++ b/alphastats/_utils.py
@@ -10,7 +10,7 @@ from alphastats.exceptions import (
 RETURNS_COLUMNS_SELECTOR = cs.numeric()
 TEMPORAL_COLUMNS_SELECTOR = cs.temporal()
 
-BENCHMARK_RETURNS = "_benchmark_returns"
+BENCHMARK_RETURNS_COLNAME = "_benchmark_returns"
 
 
 def get_temporal_column(returns: pl.LazyFrame) -> pl.Expr | None:
@@ -52,6 +52,6 @@ def prepare_benchmark(benchmark: pl.LazyFrame) -> pl.LazyFrame:
             raise AmbiguousBenchmarkReturnsError(column_names)
 
     if (temporal_col := get_temporal_column(benchmark)) is not None:
-        return benchmark.select(temporal_col, return_col.alias(BENCHMARK_RETURNS))
+        return benchmark.select(temporal_col, return_col.alias(BENCHMARK_RETURNS_COLNAME))
     else:
-        return benchmark.select(return_col.alias(BENCHMARK_RETURNS))
+        return benchmark.select(return_col.alias(BENCHMARK_RETURNS_COLNAME))

--- a/alphastats/exceptions.py
+++ b/alphastats/exceptions.py
@@ -1,0 +1,41 @@
+from collections.abc import Sequence
+
+
+class AlphaStatsError(Exception):
+    """Base exception for AlphaStats."""
+
+
+class MultipleTemporalColumnsError(AlphaStatsError):
+    """Exception raised when multiple temporal columns are found."""
+
+    def __init__(self, column_names: Sequence[str]) -> None:
+        self.column_names = column_names
+        super().__init__(f"Must have exactly one temporal column. Found {column_names}")
+
+
+class AmbiguousBenchmarkReturnsError(AlphaStatsError):
+    """Exception raised when benchmark returns columns are ambiguous."""
+
+    def __init__(self, column_names: Sequence[str]) -> None:
+        self.column_names = column_names
+        super().__init__(
+            f"Ambiguous benchmark returns columns({column_names}). Please provide a dataframe"
+            "with a single benchmark returns column."
+        )
+
+
+class NoTemporalColumnError(AlphaStatsError):
+    """Exception raised when no temporal column is found."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "This function requires a temporal column. Please provide a dataframe with a"
+            "temporal column."
+        )
+
+
+class NoReturnColumnError(AlphaStatsError):
+    """Exception raised when no return column is found."""
+
+    def __init__(self) -> None:
+        super().__init__("No return column found. Please provide a dataframe with areturn column.")

--- a/alphastats/stats.py
+++ b/alphastats/stats.py
@@ -4,7 +4,7 @@ import polars as pl
 import polars.selectors as cs
 
 from alphastats._utils import (
-    BENCHMARK_RETURNS,
+    BENCHMARK_RETURNS_COLNAME,
     RETURNS_COLUMNS_SELECTOR,
     get_temporal_column,
     prepare_benchmark,
@@ -282,12 +282,14 @@ def greeks(
     else:
         joined = pl.concat([returns_ldf, benchmark_ldf], how="horizontal")
 
-    strategy_returns_cols = RETURNS_COLUMNS_SELECTOR - cs.by_name(BENCHMARK_RETURNS)
+    strategy_returns_cols = RETURNS_COLUMNS_SELECTOR - cs.by_name(BENCHMARK_RETURNS_COLNAME)
 
     exprs: list[pl.Expr] = []
     for col_name in cs.expand_selector(joined, strategy_returns_cols):
-        beta = pl.cov(col_name, BENCHMARK_RETURNS, ddof=1) / pl.var(BENCHMARK_RETURNS, ddof=1)
-        alpha = pl.mean(col_name) - beta * pl.mean(BENCHMARK_RETURNS)
+        beta = pl.cov(col_name, BENCHMARK_RETURNS_COLNAME, ddof=1) / pl.var(
+            BENCHMARK_RETURNS_COLNAME, ddof=1
+        )
+        alpha = pl.mean(col_name) - beta * pl.mean(BENCHMARK_RETURNS_COLNAME)
 
         exprs.append(
             pl.struct(

--- a/alphastats/stats.py
+++ b/alphastats/stats.py
@@ -1,8 +1,17 @@
 from typing import overload
 
 import polars as pl
+import polars.selectors as cs
 
-from alphastats._utils import RETURNS_COLUMNS_SELECTOR, get_dt_column, to_excess_returns, to_lazy
+from alphastats._utils import (
+    BENCHMARK_RETURNS,
+    RETURNS_COLUMNS_SELECTOR,
+    get_temporal_column,
+    prepare_benchmark,
+    to_excess_returns,
+    to_lazy,
+)
+from alphastats.exceptions import NoTemporalColumnError
 
 
 @overload
@@ -62,8 +71,11 @@ def cagr(
     returns_ldf = to_lazy(returns)
 
     excess_returns = to_excess_returns(RETURNS_COLUMNS_SELECTOR, rf)
-    dt_col = get_dt_column(returns_ldf)
-    n_years = (dt_col.last() - dt_col.first()).dt.total_days() / periods
+    temporal_col = get_temporal_column(returns_ldf)
+    if temporal_col is None:
+        raise NoTemporalColumnError
+
+    n_years = (temporal_col.last() - temporal_col.first()).dt.total_days() / periods
 
     if compound:
         expr = _comp(excess_returns).add(1).pow(1 / n_years).sub(1)
@@ -234,3 +246,56 @@ def _drawdowns(expr: pl.Expr) -> pl.Expr:
     running_max_wealth_index = wealth_index.cum_max()
     drawdowns = (wealth_index / running_max_wealth_index) - 1
     return drawdowns.clip(lower_bound=None, upper_bound=0)
+
+
+def greeks(
+    returns: pl.Series | pl.DataFrame | pl.LazyFrame,
+    benchmark: pl.Series | pl.DataFrame | pl.LazyFrame,
+    periods: int = 252,
+) -> pl.DataFrame:
+    """
+    Calculate CAPM alpha & beta for every numeric column in `returns`
+    and return them as struct columns (alpha, beta).
+
+    Returns:
+        1-row DataFrame with struct columns (α·β) for each numeric column
+
+    Example:
+        ┌─────────────┬──────────────┬──────┬──────────────┐
+        │ col_1       │ col_2        │ ...  │ col_n        │
+        │ ---         │ ---          │ ---  │ ---          │
+        │ struct[α·β] │ struct[α·β]  │ ...  │ struct[α·β]  │
+        └─────────────┴──────────────┴──────┴──────────────┘
+    """
+    returns_ldf = to_lazy(returns)
+    benchmark_ldf = prepare_benchmark(to_lazy(benchmark))
+
+    returns_temporal_col = get_temporal_column(returns_ldf)
+    benchmark_temporal_col = get_temporal_column(benchmark_ldf)
+
+    if returns_temporal_col is not None and benchmark_temporal_col is not None:
+        joined = returns_ldf.join_asof(
+            benchmark_ldf,
+            left_on=returns_temporal_col,
+            right_on=benchmark_temporal_col,
+        )
+    else:
+        joined = pl.concat([returns_ldf, benchmark_ldf], how="horizontal")
+
+    strategy_returns_cols = RETURNS_COLUMNS_SELECTOR - cs.by_name(BENCHMARK_RETURNS)
+
+    exprs: list[pl.Expr] = []
+    for col_name in cs.expand_selector(joined, strategy_returns_cols):
+        beta = pl.cov(col_name, BENCHMARK_RETURNS, ddof=1) / pl.var(BENCHMARK_RETURNS, ddof=1)
+        alpha = pl.mean(col_name) - beta * pl.mean(BENCHMARK_RETURNS)
+
+        exprs.append(
+            pl.struct(
+                [
+                    (alpha * periods).alias("alpha"),
+                    beta.alias("beta"),
+                ]
+            ).alias(col_name)
+        )
+
+    return joined.select(exprs).collect()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -7,12 +7,23 @@ import pytest
 from inline_snapshot import snapshot
 
 from alphastats import stats
+from alphastats.exceptions import (
+    AmbiguousBenchmarkReturnsError,
+    MultipleTemporalColumnsError,
+    NoReturnColumnError,
+)
 
 
 @pytest.fixture
 def simple_returns_series() -> pl.Series:
     """Simple returns series for basic testing."""
     return pl.Series("returns", [0.01, -0.02, 0.03, -0.01, 0.02])
+
+
+@pytest.fixture
+def simple_benchmark_series() -> pl.Series:
+    """Simple benchmark returns series for testing."""
+    return pl.Series("_benchmark_returns", [0.005, -0.01, 0.015, -0.005, 0.01])
 
 
 @pytest.fixture
@@ -23,6 +34,28 @@ def simple_returns_df() -> pl.DataFrame:
             "date": [date(2023, 1, i) for i in range(1, 6)],
             "asset_a": [0.01, -0.02, 0.03, -0.01, 0.02],
             "asset_b": [0.02, -0.01, 0.01, 0.03, -0.02],
+        }
+    )
+
+
+@pytest.fixture
+def simple_benchmark_df() -> pl.DataFrame:
+    """Simple benchmark dataframe with temporal column."""
+    return pl.DataFrame(
+        {
+            "date": [date(2023, 1, i) for i in range(1, 6)],
+            "_benchmark_returns": [0.005, -0.01, 0.015, -0.005, 0.01],
+        }
+    )
+
+
+@pytest.fixture
+def benchmark_different_dates() -> pl.DataFrame:
+    """Benchmark data with different dates for asof join testing."""
+    return pl.DataFrame(
+        {
+            "date": [date(2023, 1, i) for i in range(1, 8)],  # More dates than returns
+            "_benchmark_returns": [0.005, -0.01, 0.015, -0.005, 0.01, 0.008, -0.003],
         }
     )
 
@@ -410,3 +443,293 @@ class TestToDrawdowns:
         single_series = pl.Series("returns", [0.05])
         result = stats.to_drawdowns(single_series)
         assert result.to_list() == snapshot([0.0])
+
+
+class TestGreeks:
+    """Test cases for the greeks (CAPM alpha & beta) function."""
+
+    def test_greeks_return_type(
+        self, simple_returns_df: pl.DataFrame, simple_benchmark_df: pl.DataFrame
+    ) -> None:
+        """Test that greeks always returns a DataFrame."""
+        # Test with DataFrame
+        result_df = stats.greeks(simple_returns_df, simple_benchmark_df)
+        assert isinstance(result_df, pl.DataFrame)
+
+        # Test with LazyFrame
+        result_lazy = stats.greeks(simple_returns_df.lazy(), simple_benchmark_df.lazy())
+        assert isinstance(result_lazy, pl.DataFrame)
+
+        # Test with Series for returns
+        result_series = stats.greeks(
+            simple_returns_df.select("asset_a").to_series(), simple_benchmark_df
+        )
+        assert isinstance(result_series, pl.DataFrame)
+
+    def test_greeks_basic_calculation_with_temporal(
+        self, simple_returns_df: pl.DataFrame, simple_benchmark_df: pl.DataFrame
+    ) -> None:
+        """Test basic greeks calculation with temporal columns."""
+        result = stats.greeks(simple_returns_df, simple_benchmark_df)
+
+        # Check that we have the expected columns
+        assert "asset_a" in result.columns
+        assert "asset_b" in result.columns
+
+        # Check that result is a single row
+        assert result.height == 1
+
+        # Check that each column contains a struct with alpha and beta
+        asset_a_struct = result["asset_a"][0]
+        assert "alpha" in asset_a_struct
+        assert "beta" in asset_a_struct
+        assert isinstance(asset_a_struct["alpha"], float)
+        assert isinstance(asset_a_struct["beta"], float)
+
+    def test_greeks_calculation_without_temporal(self) -> None:
+        """Test greeks calculation without temporal columns (horizontal concat)."""
+        returns_no_date = pl.DataFrame(
+            {
+                "asset_a": [0.01, -0.02, 0.03, -0.01, 0.02],
+                "asset_b": [0.02, -0.01, 0.01, 0.03, -0.02],
+            }
+        )
+        benchmark_no_date = pl.DataFrame(
+            {"_benchmark_returns": [0.005, -0.01, 0.015, -0.005, 0.01]}
+        )
+
+        result = stats.greeks(returns_no_date, benchmark_no_date)
+
+        # Check basic structure
+        assert isinstance(result, pl.DataFrame)
+        assert result.height == 1
+        assert "asset_a" in result.columns
+        assert "asset_b" in result.columns
+
+        assert result.to_dict(as_series=False) == snapshot(
+            {
+                "asset_a": [{"alpha": 2.185751579730777e-16, "beta": 1.9999999999999998}],
+                "asset_b": [{"alpha": 1.6702325581395348, "beta": -0.20930232558139525}],
+            }
+        )
+
+    def test_greeks_with_series_input(
+        self, simple_returns_series: pl.Series, simple_benchmark_series: pl.Series
+    ) -> None:
+        """Test greeks with series inputs."""
+        benchmark = simple_benchmark_series
+        returns = simple_returns_series
+
+        result = stats.greeks(returns, benchmark)
+
+        assert isinstance(result, pl.DataFrame)
+        assert result.height == 1
+        assert "returns" in result.columns
+
+        assert result.to_dict(as_series=False) == snapshot(
+            {"returns": [{"alpha": 2.185751579730777e-16, "beta": 1.9999999999999998}]}
+        )
+
+    def test_greeks_asof_join_different_dates(
+        self, simple_returns_df: pl.DataFrame, benchmark_different_dates: pl.DataFrame
+    ) -> None:
+        """Test greeks with asof join when benchmark has different/more dates."""
+        result = stats.greeks(simple_returns_df, benchmark_different_dates)
+
+        # Should still work with asof join
+        assert isinstance(result, pl.DataFrame)
+        assert result.height == 1
+        assert "asset_a" in result.columns
+        assert "asset_b" in result.columns
+
+        assert result.to_dict(as_series=False) == snapshot(
+            {
+                "asset_a": [{"alpha": 2.185751579730777e-16, "beta": 1.9999999999999998}],
+                "asset_b": [{"alpha": 1.6702325581395348, "beta": -0.20930232558139525}],
+            }
+        )
+
+    def test_greeks_extreme_values(self) -> None:
+        """Test greeks calculation with extreme values."""
+        extreme_returns = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "asset": [0.5, -0.8, 1.2, -0.9, 0.3],
+            }
+        )
+        extreme_benchmark = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "_benchmark_returns": [0.1, -0.2, 0.3, -0.15, 0.05],
+            }
+        )
+
+        result = stats.greeks(extreme_returns, extreme_benchmark)
+
+        assert isinstance(result, pl.DataFrame)
+        assert result.height == 1
+        assert "asset" in result.columns
+
+        assert result.to_dict(as_series=False) == snapshot(
+            {"asset": [{"alpha": -6.957055214723923, "beta": 4.380368098159508}]}
+        )
+
+    def test_greeks_single_asset(self) -> None:
+        """Test greeks with single asset."""
+        single_asset_returns = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "single_asset": [0.01, -0.02, 0.03, -0.01, 0.02],
+            }
+        )
+        benchmark = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "_benchmark_returns": [0.005, -0.01, 0.015, -0.005, 0.01],
+            }
+        )
+
+        result = stats.greeks(single_asset_returns, benchmark)
+
+        assert isinstance(result, pl.DataFrame)
+        assert result.height == 1
+        assert len(result.columns) == 1
+        assert "single_asset" in result.columns
+
+        assert result.to_dict(as_series=False) == snapshot(
+            {"single_asset": [{"alpha": 2.185751579730777e-16, "beta": 1.9999999999999998}]}
+        )
+
+    def test_greeks_zero_variance_benchmark(self) -> None:
+        """Test greeks with zero variance benchmark (should handle division by zero)."""
+        returns = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "asset": [0.01, -0.02, 0.03, -0.01, 0.02],
+            }
+        )
+        zero_var_benchmark = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "_benchmark_returns": [0.01, 0.01, 0.01, 0.01, 0.01],  # No variance
+            }
+        )
+
+        result = stats.greeks(returns, zero_var_benchmark)
+
+        assert isinstance(result, pl.DataFrame)
+        assert result.height == 1
+
+        # Beta should be infinity when benchmark variance is zero
+        asset_struct = result.item()
+        assert math.isinf(asset_struct["beta"]) or math.isnan(asset_struct["beta"])
+
+    def test_greeks_perfect_correlation(self) -> None:
+        """Test greeks when returns and benchmark are perfectly correlated."""
+        returns = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "asset": [0.02, -0.04, 0.06, -0.02, 0.04],  # 2x the benchmark
+            }
+        )
+        benchmark = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "_benchmark_returns": [0.01, -0.02, 0.03, -0.01, 0.02],
+            }
+        )
+
+        result = stats.greeks(returns, benchmark)
+
+        assert isinstance(result, pl.DataFrame)
+        assert result.height == 1
+
+        asset_struct = result.item()
+        # Beta should be close to 2.0 for perfectly correlated 2x returns
+        assert abs(asset_struct["beta"] - 2.0) < 0.1
+
+    def test_greeks_benchmark_no_numeric_columns_error(self) -> None:
+        """Test greeks raises NoReturnColumnError when benchmark has no numeric columns."""
+        returns = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "asset": [0.01, -0.02, 0.03, -0.01, 0.02],
+            }
+        )
+        # Benchmark with only non-numeric columns
+        invalid_benchmark = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "name": ["A", "B", "C", "D", "E"],  # String column, not numeric
+            }
+        )
+
+        with pytest.raises(NoReturnColumnError):
+            stats.greeks(returns, invalid_benchmark)
+
+    def test_greeks_benchmark_multiple_numeric_columns_error(self) -> None:
+        """
+        Test greeks raises AmbiguousBenchmarkReturnsError when benchmark has multiple numeric
+        columns
+        """
+        returns = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "asset": [0.01, -0.02, 0.03, -0.01, 0.02],
+            }
+        )
+        # Benchmark with multiple numeric columns
+        ambiguous_benchmark = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "benchmark_1": [0.005, -0.01, 0.015, -0.005, 0.01],
+                "benchmark_2": [0.008, -0.012, 0.018, -0.008, 0.012],
+            }
+        )
+
+        with pytest.raises(AmbiguousBenchmarkReturnsError):
+            stats.greeks(returns, ambiguous_benchmark)
+
+    def test_greeks_multiple_temporal_columns_error_returns(self) -> None:
+        """
+        Test greeks raises MultipleTemporalColumnsError when returns has multiple temporal columns
+        """
+        # Returns with multiple temporal columns
+        invalid_returns = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "datetime": [datetime.datetime(2023, 1, i) for i in range(1, 6)],
+                "asset": [0.01, -0.02, 0.03, -0.01, 0.02],
+            }
+        )
+        benchmark = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "_benchmark_returns": [0.005, -0.01, 0.015, -0.005, 0.01],
+            }
+        )
+
+        with pytest.raises(MultipleTemporalColumnsError):
+            stats.greeks(invalid_returns, benchmark)
+
+    def test_greeks_multiple_temporal_columns_error_benchmark(self) -> None:
+        """
+        Test greeks raises MultipleTemporalColumnsError when benchmark has multiple temporal columns
+        """
+        returns = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "asset": [0.01, -0.02, 0.03, -0.01, 0.02],
+            }
+        )
+        # Benchmark with multiple temporal columns
+        invalid_benchmark = pl.DataFrame(
+            {
+                "date": [date(2023, 1, i) for i in range(1, 6)],
+                "datetime": [datetime.datetime(2023, 1, i) for i in range(1, 6)],
+                "_benchmark_returns": [0.005, -0.01, 0.015, -0.005, 0.01],
+            }
+        )
+
+        with pytest.raises(MultipleTemporalColumnsError):
+            stats.greeks(returns, invalid_benchmark)


### PR DESCRIPTION
**리뷰어가 작업내용을 이해하기 쉽도록 아래내용을 상세히 작성해주세요.**

## Changes

alpha, beta를 구하기 위한 greeks 지표를 추가하였습니다.

### 복수개의 returns 컬럼에 관해
- quantstats의 경우, returns 데이터프레임에 여러 전략(자산)에 대한 수익률 컬럼이 있는 경우에도, 첫 번째 컬럼의 greeks만 계산합니다.
- 다른 모든 지표는 복수개의 수익률 컬럼에 대한 지표 계산을 지원하지만, greeks만 예외로 동작하는 것은 pandas의 한계로 인한 것으로 추측하였습니다. (각 전략에 대해 alpha, beta를 응답하는 것은 multiindex column이 아니라면 불가능)
- polars에서는 struct 데이터타입을 사용할 수 있으므로, 위와 같은 한계점을 개선하였습니다.

### 벤치마크에 관해

다른 지표와 다르게, greeks 계산에는 벤치마크가 필요합니다.
- returns(포트폴리오 수익률 데이터)와 benchmark(벤치마크 데이터)가 temporal한 column을 갖고 있는 경우: 포트폴리오 수익률 데이터를 기준으로 asof join을 하여 시간축을 align합니다.
- else: horizontal하게 concat 후 연산합니다.

## Test

> **💡** _진행한 테스트에 대해서 구체적으로 작성해주세요._

- 테스트케이스 추가 후 통과 여부를 확인하였습니다.
