### PR TITLE
feat: metrics 리포트 추가

### DIFF
--- a/alphastats/__init__.py
+++ b/alphastats/__init__.py
@@ -1,0 +1,4 @@
+from alphastats import stats
+from alphastats.reports import metrics
+
+__all__ = ["metrics", "stats"]

--- a/alphastats/reports.py
+++ b/alphastats/reports.py
@@ -1,0 +1,621 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from datetime import date, datetime
+from typing import Any, cast
+
+import polars as pl
+import polars.selectors as cs
+
+from alphastats import stats
+from alphastats._utils import (
+    RETURNS_COLUMNS_SELECTOR,
+    get_temporal_column,
+)
+
+ReturnFrame = pl.DataFrame | pl.LazyFrame
+Returns = pl.Series | ReturnFrame
+MetricFunc = Callable[[pl.Series], Any]
+
+
+def metrics(
+    returns: Returns,
+    benchmark: Returns | None = None,
+    rf: float = 0.0,
+    display: bool = True,
+    mode: str = "basic",
+    sep: bool = False,
+    compounded: bool = True,
+    periods_per_year: int = 252,
+    prepare_returns: bool = True,
+    match_dates: bool = True,
+    **kwargs: Any,
+) -> pl.DataFrame | None:
+    """Calculate a QuantStats-style performance metrics table."""
+    del prepare_returns
+
+    report = _prepare_report_frame(
+        returns,
+        benchmark,
+        match_dates=match_dates,
+        strategy_title=kwargs.get("strategy_title", "Strategy"),
+        benchmark_title=kwargs.get("benchmark_title", "Benchmark"),
+    )
+    pct = 100 if display or "internal" in kwargs or kwargs.get("as_pct", False) else 1
+    full = mode.lower() == "full"
+
+    rows: list[tuple[str, dict[str, Any]]] = []
+
+    def add(label: str, values: dict[str, Any]) -> None:
+        rows.append((label, values))
+
+    def add_sep() -> None:
+        if sep:
+            rows.append(("", dict.fromkeys(report.output_names, "")))
+
+    add(
+        "Start Period",
+        {name: _format_date(report.start_dates.get(name)) for name in report.output_names},
+    )
+    add(
+        "End Period",
+        {name: _format_date(report.end_dates.get(name)) for name in report.output_names},
+    )
+    add("Risk-Free Rate", dict.fromkeys(report.output_names, rf * pct))
+    add("Time in Market", _series_metric(report, stats.exposure, multiplier=pct))
+    add_sep()
+
+    if compounded:
+        add("Cumulative Return", _series_metric(report, stats.comp, multiplier=pct))
+    else:
+        add("Total Return", {name: _sum(series) * pct for name, series in report.series.items()})
+    add(
+        "CAGR﹪",
+        _series_cagr(
+            report, rf=rf, compounded=compounded, periods=periods_per_year, multiplier=pct
+        ),
+    )
+    add_sep()
+
+    add(
+        "Sharpe",
+        _series_metric(
+            report, lambda series: stats.sharpe(series, rf=rf, periods=periods_per_year)
+        ),
+    )
+    add(
+        "Prob. Sharpe Ratio",
+        _series_metric(
+            report,
+            lambda series: stats.probabilistic_sharpe_ratio(
+                series, rf=rf, periods=periods_per_year, annualize=False
+            ),
+            multiplier=pct,
+        ),
+    )
+    if full:
+        add(
+            "Smart Sharpe",
+            _series_metric(
+                report, lambda series: stats.smart_sharpe(series, rf=rf, periods=periods_per_year)
+            ),
+        )
+    add(
+        "Sortino",
+        _series_metric(
+            report, lambda series: stats.sortino(series, rf=rf, periods=periods_per_year)
+        ),
+    )
+    if full:
+        add(
+            "Smart Sortino",
+            _series_metric(
+                report, lambda series: stats.smart_sortino(series, rf=rf, periods=periods_per_year)
+            ),
+        )
+    add(
+        "Sortino/√2",
+        _series_metric(
+            report, lambda series: stats.adjusted_sortino(series, rf=rf, periods=periods_per_year)
+        ),
+    )
+    if full:
+        add(
+            "Smart Sortino/√2",
+            _series_metric(
+                report,
+                lambda series: stats.smart_adjusted_sortino(
+                    series, rf=rf, periods=periods_per_year
+                ),
+            ),
+        )
+    add("Omega", _series_metric(report, stats.omega))
+    add_sep()
+
+    drawdowns = {
+        name: _drawdown_details(series, report.dates) for name, series in report.series.items()
+    }
+    add(
+        "Max Drawdown", {name: details["max_drawdown"] * pct for name, details in drawdowns.items()}
+    )
+    add("Max DD Date", {name: _format_date(details["date"]) for name, details in drawdowns.items()})
+    add(
+        "Max DD Period Start",
+        {name: _format_date(details["start"]) for name, details in drawdowns.items()},
+    )
+    add(
+        "Max DD Period End",
+        {name: _format_date(details["end"]) for name, details in drawdowns.items()},
+    )
+    add("Longest DD Days", _series_metric(report, stats.longest_drawdown_days))
+
+    if full:
+        add_sep()
+        add(
+            "Volatility (ann.)",
+            _series_metric(
+                report,
+                lambda series: stats.volatility(series, periods=periods_per_year),
+                multiplier=pct,
+            ),
+        )
+        if benchmark is not None:
+            add(
+                "R^2",
+                _benchmark_metric(report, lambda series, bench: stats.r_squared(series, bench)),
+            )
+            add(
+                "Information Ratio",
+                _benchmark_metric(
+                    report, lambda series, bench: stats.information_ratio(series, bench)
+                ),
+            )
+        add(
+            "Calmar",
+            _series_cagr(
+                report,
+                rf=0.0,
+                compounded=compounded,
+                periods=periods_per_year,
+                multiplier=1,
+                divide_by_mdd=True,
+            ),
+        )
+        add("Skew", _series_metric(report, stats.skew))
+        add("Kurtosis", _series_metric(report, stats.kurtosis))
+        add(
+            "Avg. Return",
+            _series_metric(
+                report,
+                lambda series: stats.avg_return(series, compounded=compounded),
+                multiplier=pct,
+            ),
+        )
+        add(
+            "Avg. Win",
+            _series_metric(
+                report, lambda series: stats.avg_win(series, compounded=compounded), multiplier=pct
+            ),
+        )
+        add(
+            "Avg. Loss",
+            _series_metric(
+                report, lambda series: stats.avg_loss(series, compounded=compounded), multiplier=pct
+            ),
+        )
+        add("Kelly Criterion", _series_metric(report, stats.kelly_criterion, multiplier=pct))
+        add("Risk of Ruin", _series_metric(report, stats.risk_of_ruin))
+        add("Daily Value-at-Risk", _series_metric(report, stats.value_at_risk, multiplier=pct))
+        add(
+            "Expected Shortfall (cVaR)",
+            _series_metric(report, stats.conditional_value_at_risk, multiplier=pct),
+        )
+        add("Max Consecutive Wins", _series_metric(report, stats.consecutive_wins))
+        add("Max Consecutive Losses", _series_metric(report, stats.consecutive_losses))
+
+    add_sep()
+    add(
+        "Gain/Pain Ratio",
+        _series_metric(report, lambda series: stats.gain_to_pain_ratio(series, rf=rf)),
+    )
+    add(
+        "Gain/Pain (1M)",
+        _monthly_metric(report, lambda frame: stats.gain_to_pain_ratio_1m(frame, rf=rf)),
+    )
+    add_sep()
+    add("Payoff Ratio", _series_metric(report, stats.payoff_ratio))
+    add("Profit Factor", _series_metric(report, stats.profit_factor))
+    add("Common Sense Ratio", _series_metric(report, stats.common_sense_ratio))
+    add("CPC Index", _series_metric(report, stats.cpc_index))
+    add("Tail Ratio", _series_metric(report, stats.tail_ratio))
+    add("Outlier Win Ratio", _series_metric(report, stats.outlier_win_ratio))
+    add("Outlier Loss Ratio", _series_metric(report, stats.outlier_loss_ratio))
+    add_sep()
+
+    add("MTD", _window_metric(report, stats.mtd, multiplier=pct))
+    add("3M", _window_metric(report, stats.three_month, multiplier=pct))
+    add("6M", _window_metric(report, stats.six_month, multiplier=pct))
+    add("YTD", _window_metric(report, stats.ytd, multiplier=pct))
+    add("1Y", _window_metric(report, stats.one_year, multiplier=pct))
+    add(
+        "3Y (ann.)",
+        _window_metric(
+            report, lambda frame: stats.three_year(frame, periods=periods_per_year), multiplier=pct
+        ),
+    )
+    add(
+        "5Y (ann.)",
+        _window_metric(
+            report, lambda frame: stats.five_year(frame, periods=periods_per_year), multiplier=pct
+        ),
+    )
+    add(
+        "10Y (ann.)",
+        _window_metric(
+            report, lambda frame: stats.ten_year(frame, periods=periods_per_year), multiplier=pct
+        ),
+    )
+    add(
+        "All-time (ann.)",
+        _series_cagr(
+            report, rf=0.0, compounded=compounded, periods=periods_per_year, multiplier=pct
+        ),
+    )
+
+    if full:
+        add_sep()
+        add("Best Day", _series_metric(report, stats.best_day, multiplier=pct))
+        add("Worst Day", _series_metric(report, stats.worst_day, multiplier=pct))
+        add("Best Month", _monthly_metric(report, stats.best_month, multiplier=pct))
+        add("Worst Month", _monthly_metric(report, stats.worst_month, multiplier=pct))
+        add("Best Year", _monthly_metric(report, stats.best_year, multiplier=pct))
+        add("Worst Year", _monthly_metric(report, stats.worst_year, multiplier=pct))
+
+    add_sep()
+    add("Avg. Drawdown", _series_metric(report, stats.avg_drawdown, multiplier=pct))
+    add("Avg. Drawdown Days", _series_metric(report, stats.avg_drawdown_days))
+    add("Recovery Factor", _series_metric(report, stats.recovery_factor))
+    add("Ulcer Index", _series_metric(report, stats.ulcer_index))
+    add(
+        "Serenity Index", _series_metric(report, lambda series: stats.serenity_index(series, rf=rf))
+    )
+
+    if full:
+        add_sep()
+        add("Avg. Up Month", _monthly_metric(report, stats.avg_up_month, multiplier=pct))
+        add("Avg. Down Month", _monthly_metric(report, stats.avg_down_month, multiplier=pct))
+        add("Win Days", _series_metric(report, stats.win_days, multiplier=pct))
+        add("Win Month", _monthly_metric(report, stats.win_month, multiplier=pct))
+        add("Win Quarter", _monthly_metric(report, stats.win_quarter, multiplier=pct))
+        add("Win Year", _monthly_metric(report, stats.win_year, multiplier=pct))
+        if benchmark is not None:
+            add_sep()
+            add(
+                "Beta",
+                _benchmark_metric(report, lambda series, bench: _greek(series, bench, "beta")),
+            )
+            add(
+                "Alpha",
+                _benchmark_metric(report, lambda series, bench: _greek(series, bench, "alpha")),
+            )
+            add(
+                "Correlation",
+                _benchmark_metric(
+                    report, lambda series, bench: stats.correlation(series, bench), multiplier=pct
+                ),
+            )
+            add(
+                "Treynor Ratio",
+                _benchmark_metric(
+                    report,
+                    lambda series, bench: stats.treynor_ratio(series, bench, rf=rf),
+                    multiplier=pct,
+                ),
+            )
+
+    result = _build_output(rows, report.output_names)
+    if display:
+        print(result)
+        return None
+    return result
+
+
+class _ReportFrame:
+    def __init__(
+        self,
+        frame: pl.DataFrame,
+        series: dict[str, pl.Series],
+        output_names: list[str],
+        benchmark_name: str | None,
+        dates: list[Any] | None,
+    ) -> None:
+        self.frame = frame
+        self.series = series
+        self.output_names = output_names
+        self.benchmark_name = benchmark_name
+        self.dates = dates
+        self.start_dates = _period_dates(frame, output_names, dates, first=True)
+        self.end_dates = _period_dates(frame, output_names, dates, first=False)
+
+
+def _prepare_report_frame(
+    returns: Returns,
+    benchmark: Returns | None,
+    *,
+    match_dates: bool,
+    strategy_title: str | list[str],
+    benchmark_title: str,
+) -> _ReportFrame:
+    frame = _to_frame(returns)
+    temporal_name = _temporal_name(frame)
+    return_names = list(cs.expand_selector(frame.lazy(), RETURNS_COLUMNS_SELECTOR))
+    if not return_names:
+        msg = "`returns` must contain at least one numeric return column"
+        raise ValueError(msg)
+
+    if len(return_names) == 1 and isinstance(strategy_title, str):
+        output_names = [strategy_title]
+    elif isinstance(strategy_title, list):
+        output_names = strategy_title
+    else:
+        output_names = return_names
+
+    if len(output_names) != len(return_names):
+        msg = "`strategy_title` must match the number of strategy return columns"
+        raise ValueError(msg)
+
+    selected = [
+        pl.col(name).alias(output) for name, output in zip(return_names, output_names, strict=True)
+    ]
+    if temporal_name:
+        selected.insert(0, pl.col(temporal_name))
+    frame = frame.select(selected)
+
+    benchmark_name = None
+    if benchmark is not None:
+        benchmark_frame = _to_frame(benchmark)
+        benchmark_temporal = _temporal_name(benchmark_frame)
+        benchmark_cols = list(cs.expand_selector(benchmark_frame.lazy(), RETURNS_COLUMNS_SELECTOR))
+        if len(benchmark_cols) != 1:
+            msg = "`benchmark` must contain exactly one numeric return column"
+            raise ValueError(msg)
+        benchmark_name = benchmark_title
+        benchmark_frame = benchmark_frame.select(
+            *([pl.col(benchmark_temporal)] if benchmark_temporal else []),
+            pl.col(benchmark_cols[0]).alias(benchmark_name),
+        )
+        if temporal_name and benchmark_temporal:
+            if match_dates:
+                frame = frame.join(
+                    benchmark_frame,
+                    left_on=temporal_name,
+                    right_on=benchmark_temporal,
+                    how="inner",
+                )
+            else:
+                frame = frame.join(
+                    benchmark_frame,
+                    left_on=temporal_name,
+                    right_on=benchmark_temporal,
+                    how="left",
+                )
+        else:
+            frame = pl.concat([frame, benchmark_frame.select(benchmark_name)], how="horizontal")
+        output_names = [benchmark_name, *output_names]
+
+    frame = frame.fill_nan(None)
+    dates = frame[temporal_name].to_list() if temporal_name else None
+    series = {name: frame[name].fill_null(0) for name in output_names}
+    return _ReportFrame(frame, series, output_names, benchmark_name, dates)
+
+
+def _to_frame(returns: Returns) -> pl.DataFrame:
+    if isinstance(returns, pl.Series):
+        return pl.DataFrame(returns)
+    if isinstance(returns, pl.LazyFrame):
+        return returns.collect()
+    return returns
+
+
+def _temporal_name(frame: pl.DataFrame) -> str | None:
+    temporal = get_temporal_column(frame.lazy())
+    if temporal is None:
+        return None
+    return temporal.meta.output_name()
+
+
+def _series_metric(
+    report: _ReportFrame, func: MetricFunc, multiplier: float = 1.0
+) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for name, series in report.series.items():
+        values[name] = _number(func(series), multiplier=multiplier)
+    return values
+
+
+def _benchmark_metric(
+    report: _ReportFrame,
+    func: Callable[[pl.Series, pl.Series], Any],
+    multiplier: float = 1.0,
+) -> dict[str, Any]:
+    values = dict.fromkeys(report.output_names, "-")
+    if report.benchmark_name is None:
+        return values
+    benchmark = report.series[report.benchmark_name]
+    for name, series in report.series.items():
+        if name == report.benchmark_name:
+            continue
+        values[name] = _number(func(series, benchmark), multiplier=multiplier)
+    return values
+
+
+def _monthly_metric(
+    report: _ReportFrame,
+    func: Callable[[ReturnFrame], Any],
+    multiplier: float = 1.0,
+) -> dict[str, Any]:
+    if report.dates is None:
+        return dict.fromkeys(report.output_names, "-")
+    values: dict[str, Any] = {}
+    for name in report.output_names:
+        frame = pl.DataFrame({"date": report.dates, name: report.series[name]})
+        values[name] = _frame_value(func(frame), name, multiplier=multiplier)
+    return values
+
+
+def _window_metric(
+    report: _ReportFrame,
+    func: Callable[[ReturnFrame], Any],
+    multiplier: float = 1.0,
+) -> dict[str, Any]:
+    if report.dates is None:
+        return dict.fromkeys(report.output_names, "-")
+    values: dict[str, Any] = {}
+    for name in report.output_names:
+        frame = pl.DataFrame({"date": report.dates, name: report.series[name]})
+        values[name] = _frame_value(func(frame), name, multiplier=multiplier)
+    return values
+
+
+def _series_cagr(
+    report: _ReportFrame,
+    *,
+    rf: float,
+    compounded: bool,
+    periods: int,
+    multiplier: float,
+    divide_by_mdd: bool = False,
+) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for name, series in report.series.items():
+        cagr_value = _cagr(series, rf=rf, compounded=compounded, periods=periods)
+        if divide_by_mdd:
+            max_dd = abs(stats.max_drawdown(series))
+            values[name] = cagr_value / max_dd if max_dd else math.nan
+        else:
+            values[name] = cagr_value * multiplier
+    return values
+
+
+def _cagr(series: pl.Series, *, rf: float, compounded: bool, periods: int) -> float:
+    values = [float(value) - rf for value in series.drop_nulls().to_list()]
+    if not values:
+        return math.nan
+    n_years = len(values) / periods
+    total = math.prod(1 + value for value in values) if compounded else sum(values) + 1
+    return total ** (1 / n_years) - 1
+
+
+def _drawdown_details(series: pl.Series, dates: list[Any] | None) -> dict[str, Any]:
+    drawdowns = stats.to_drawdowns(series).to_list()
+    if not drawdowns:
+        return {"max_drawdown": math.nan, "date": None, "start": None, "end": None}
+    min_value = min(float(value) for value in drawdowns if value is not None)
+    min_idx = next(idx for idx, value in enumerate(drawdowns) if value == min_value)
+
+    start_idx = min_idx
+    while start_idx > 0 and drawdowns[start_idx - 1] is not None and drawdowns[start_idx - 1] < 0:
+        start_idx -= 1
+    end_idx = min_idx
+    while (
+        end_idx + 1 < len(drawdowns)
+        and drawdowns[end_idx + 1] is not None
+        and drawdowns[end_idx + 1] < 0
+    ):
+        end_idx += 1
+
+    return {
+        "max_drawdown": min_value,
+        "date": _date_at(dates, min_idx),
+        "start": _date_at(dates, start_idx),
+        "end": _date_at(dates, end_idx),
+    }
+
+
+def _period_dates(
+    frame: pl.DataFrame,
+    names: list[str],
+    dates: list[Any] | None,
+    *,
+    first: bool,
+) -> dict[str, Any]:
+    if dates is None:
+        return dict.fromkeys(names)
+    result: dict[str, Any] = {}
+    for name in names:
+        values = frame[name].to_list()
+        indexes = [idx for idx, value in enumerate(values) if value is not None]
+        result[name] = _date_at(dates, indexes[0 if first else -1]) if indexes else None
+    return result
+
+
+def _date_at(dates: list[Any] | None, idx: int) -> Any:
+    if dates is None:
+        return None
+    return dates[idx]
+
+
+def _frame_value(result: Any, column: str, multiplier: float = 1.0) -> Any:
+    if isinstance(result, pl.DataFrame):
+        return _number(result[column][0], multiplier=multiplier)
+    return _number(result, multiplier=multiplier)
+
+
+def _greek(series: pl.Series, benchmark: pl.Series, field: str) -> float:
+    greeks = stats.greeks(series, benchmark)
+    return float(cast(dict[str, float], greeks[series.name][0])[field])
+
+
+def _number(value: Any, multiplier: float = 1.0) -> Any:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, int):
+        return value * multiplier
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return value
+    return numeric * multiplier
+
+
+def _sum(series: pl.Series) -> float:
+    return sum(float(value) for value in series.drop_nulls().to_list())
+
+
+def _format_date(value: Any) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value)
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, str):
+        return value
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return "-"
+        rounded = round(value, 2)
+        if rounded == 0:
+            rounded = 0
+        return str(rounded)
+    return str(value)
+
+
+def _build_output(rows: list[tuple[str, dict[str, Any]]], output_names: list[str]) -> pl.DataFrame:
+    data: dict[str, list[str]] = {"Metric": []}
+    for name in output_names:
+        data[name] = []
+    for label, values in rows:
+        data["Metric"].append(label)
+        for name in output_names:
+            data[name].append(_format_value(values.get(name)))
+    return pl.DataFrame(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alphastats"
-version = "0.1.1"
+version = "0.2.0"
 description = "Blazing-fast portfolio analytics powered by Polars, with a QuantStats-style API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_quantstats_parity.py
+++ b/tests/test_quantstats_parity.py
@@ -6,9 +6,10 @@ from typing import SupportsFloat, cast
 import pandas as pd
 import polars as pl
 import pytest
+import quantstats.reports as qr
 import quantstats.stats as qs
 
-from alphastats import stats
+from alphastats import reports, stats
 
 pytestmark = [
     pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning"),
@@ -281,3 +282,80 @@ def test_report_window_wrappers_match_equivalent_quantstats_outputs() -> None:
     assert_close(stats.five_year(polars_returns)["asset"][0], filtered_cagr(pandas_returns, 5))
     assert_close(stats.ten_year(polars_returns)["asset"][0], filtered_cagr(pandas_returns, 10))
     assert_close(stats.all_time(polars_returns)["asset"][0], filtered_cagr(pandas_returns))
+
+
+def test_basic_report_metrics_match_quantstats_values() -> None:
+    pandas_returns = returns_series()
+    pandas_benchmark = benchmark_series()
+    polars_returns = to_polars_frame(pandas_returns)
+    polars_benchmark = to_polars_frame(pandas_benchmark, "benchmark")
+
+    actual = reports.metrics(
+        polars_returns,
+        benchmark=polars_benchmark,
+        display=False,
+        mode="basic",
+    )
+    expected = qr.metrics(
+        pandas_returns,
+        benchmark=pandas_benchmark,
+        display=False,
+        mode="basic",
+    )
+
+    assert actual is not None
+    actual_by_metric = {row["Metric"]: row for row in actual.to_dicts()}
+    for metric in [
+        "Start Period",
+        "End Period",
+        "Time in Market",
+        "Cumulative Return",
+        "CAGR﹪",
+        "Sharpe",
+        "Sortino",
+        "Max Drawdown",
+        "Gain/Pain Ratio",
+        "Payoff Ratio",
+        "Profit Factor",
+        "Recovery Factor",
+        "Serenity Index",
+    ]:
+        assert actual_by_metric[metric]["Benchmark"] == str(expected.loc[metric, "Benchmark"])
+        assert actual_by_metric[metric]["Strategy"] == str(expected.loc[metric, "Strategy"])
+
+
+def test_full_report_metrics_include_benchmark_relative_rows() -> None:
+    pandas_returns = returns_series()
+    pandas_benchmark = benchmark_series()
+    polars_returns = to_polars_frame(pandas_returns)
+    polars_benchmark = to_polars_frame(pandas_benchmark, "benchmark")
+
+    actual = reports.metrics(
+        polars_returns,
+        benchmark=polars_benchmark,
+        display=False,
+        mode="full",
+    )
+    expected = qr.metrics(
+        pandas_returns,
+        benchmark=pandas_benchmark,
+        display=False,
+        mode="full",
+    )
+
+    assert actual is not None
+    actual_by_metric = {row["Metric"]: row for row in actual.to_dicts()}
+    for metric in [
+        "Volatility (ann.)",
+        "Calmar",
+        "Skew",
+        "Kurtosis",
+        "Beta",
+        "Alpha",
+    ]:
+        assert actual_by_metric[metric]["Benchmark"] == str(expected.loc[metric, "Benchmark"])
+        assert actual_by_metric[metric]["Strategy"] == str(expected.loc[metric, "Strategy"])
+
+    for metric in ["R^2", "Information Ratio"]:
+        assert actual_by_metric[metric]["Benchmark"] == "-"
+        assert actual_by_metric[metric]["Strategy"] == str(expected.loc[metric, "Strategy"])

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "alphastats"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },


### PR DESCRIPTION
**리뷰어가 작업내용을 이해하기 쉽도록 아래내용을 상세히 작성해주세요.**

## Changes

- QuantStats의 `reports.metrics`와 유사한 보고서형 metrics API를 `alphastats.reports.metrics`로 추가했습니다.
- `from alphastats import metrics`로도 사용할 수 있도록 top-level export를 추가했습니다.
- Polars에는 pandas index가 없으므로 반환 테이블은 `Metric` 컬럼을 포함하는 `pl.DataFrame` 형태로 제공합니다.
- `uv version --bump minor`로 패키지 버전을 `0.1.1`에서 `0.2.0`으로 올렸습니다.
- QuantStats `reports.metrics` 출력과 주요 basic/full 지표 값이 일치하는지 비교하는 parity 테스트를 추가했습니다.

## Test

> **💡** _진행한 테스트에 대해서 구체적으로 작성해주세요._

- `uv run pytest -q` 통과: 168 passed
- `uv run ruff check .` 통과
- `uv run mypy alphastats tests` 통과
- 커밋 시 pre-commit 훅 통과: ruff, ruff-format, mypy, commit message 검증

## Task Link

> **💡** _관련 페이지 링크를 작성해주세요._

- 없음