### PR TITLE
fix: reports 지표 순서 호환성 복원

### DIFF
--- a/alphastats/reports.py
+++ b/alphastats/reports.py
@@ -133,21 +133,7 @@ def metrics(
     add("Omega", _series_metric(report, stats.omega))
     add_sep()
 
-    drawdowns = {
-        name: _drawdown_details(series, report.dates) for name, series in report.series.items()
-    }
-    add(
-        "Max Drawdown", {name: details["max_drawdown"] * pct for name, details in drawdowns.items()}
-    )
-    add("Max DD Date", {name: _format_date(details["date"]) for name, details in drawdowns.items()})
-    add(
-        "Max DD Period Start",
-        {name: _format_date(details["start"]) for name, details in drawdowns.items()},
-    )
-    add(
-        "Max DD Period End",
-        {name: _format_date(details["end"]) for name, details in drawdowns.items()},
-    )
+    add("Max Drawdown", _series_metric(report, stats.max_drawdown, multiplier=pct))
     add("Longest DD Days", _series_metric(report, stats.longest_drawdown_days))
 
     if full:
@@ -184,26 +170,9 @@ def metrics(
         )
         add("Skew", _series_metric(report, stats.skew))
         add("Kurtosis", _series_metric(report, stats.kurtosis))
-        add(
-            "Avg. Return",
-            _series_metric(
-                report,
-                lambda series: stats.avg_return(series, compounded=compounded),
-                multiplier=pct,
-            ),
-        )
-        add(
-            "Avg. Win",
-            _series_metric(
-                report, lambda series: stats.avg_win(series, compounded=compounded), multiplier=pct
-            ),
-        )
-        add(
-            "Avg. Loss",
-            _series_metric(
-                report, lambda series: stats.avg_loss(series, compounded=compounded), multiplier=pct
-            ),
-        )
+        add("Expected Daily", _series_metric(report, stats.expected_daily, multiplier=pct))
+        add("Expected Monthly", _monthly_metric(report, stats.expected_monthly, multiplier=pct))
+        add("Expected Yearly", _monthly_metric(report, stats.expected_yearly, multiplier=pct))
         add("Kelly Criterion", _series_metric(report, stats.kelly_criterion, multiplier=pct))
         add("Risk of Ruin", _series_metric(report, stats.risk_of_ruin))
         add("Daily Value-at-Risk", _series_metric(report, stats.value_at_risk, multiplier=pct))
@@ -505,32 +474,6 @@ def _cagr(series: pl.Series, *, rf: float, compounded: bool, periods: int) -> fl
     n_years = len(values) / periods
     total = math.prod(1 + value for value in values) if compounded else sum(values) + 1
     return total ** (1 / n_years) - 1
-
-
-def _drawdown_details(series: pl.Series, dates: list[Any] | None) -> dict[str, Any]:
-    drawdowns = stats.to_drawdowns(series).to_list()
-    if not drawdowns:
-        return {"max_drawdown": math.nan, "date": None, "start": None, "end": None}
-    min_value = min(float(value) for value in drawdowns if value is not None)
-    min_idx = next(idx for idx, value in enumerate(drawdowns) if value == min_value)
-
-    start_idx = min_idx
-    while start_idx > 0 and drawdowns[start_idx - 1] is not None and drawdowns[start_idx - 1] < 0:
-        start_idx -= 1
-    end_idx = min_idx
-    while (
-        end_idx + 1 < len(drawdowns)
-        and drawdowns[end_idx + 1] is not None
-        and drawdowns[end_idx + 1] < 0
-    ):
-        end_idx += 1
-
-    return {
-        "max_drawdown": min_value,
-        "date": _date_at(dates, min_idx),
-        "start": _date_at(dates, start_idx),
-        "end": _date_at(dates, end_idx),
-    }
 
 
 def _period_dates(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alphastats"
-version = "0.2.0"
+version = "0.2.1"
 description = "Blazing-fast portfolio analytics powered by Polars, with a QuantStats-style API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_quantstats_parity.py
+++ b/tests/test_quantstats_parity.py
@@ -54,6 +54,119 @@ def to_polars_series(series: pd.Series, column_name: str = "asset") -> pl.Series
     return pl.Series(column_name, [float(value) for value in series.to_list()])
 
 
+LEGACY_BASIC_REPORT_METRICS = [
+    "Start Period",
+    "End Period",
+    "Risk-Free Rate",
+    "Time in Market",
+    "Cumulative Return",
+    "CAGR﹪",
+    "Sharpe",
+    "Prob. Sharpe Ratio",
+    "Sortino",
+    "Sortino/√2",
+    "Omega",
+    "Max Drawdown",
+    "Longest DD Days",
+    "Gain/Pain Ratio",
+    "Gain/Pain (1M)",
+    "Payoff Ratio",
+    "Profit Factor",
+    "Common Sense Ratio",
+    "CPC Index",
+    "Tail Ratio",
+    "Outlier Win Ratio",
+    "Outlier Loss Ratio",
+    "MTD",
+    "3M",
+    "6M",
+    "YTD",
+    "1Y",
+    "3Y (ann.)",
+    "5Y (ann.)",
+    "10Y (ann.)",
+    "All-time (ann.)",
+    "Avg. Drawdown",
+    "Avg. Drawdown Days",
+    "Recovery Factor",
+    "Ulcer Index",
+    "Serenity Index",
+]
+
+LEGACY_FULL_REPORT_METRICS = [
+    "Start Period",
+    "End Period",
+    "Risk-Free Rate",
+    "Time in Market",
+    "Cumulative Return",
+    "CAGR﹪",
+    "Sharpe",
+    "Prob. Sharpe Ratio",
+    "Smart Sharpe",
+    "Sortino",
+    "Smart Sortino",
+    "Sortino/√2",
+    "Smart Sortino/√2",
+    "Omega",
+    "Max Drawdown",
+    "Longest DD Days",
+    "Volatility (ann.)",
+    "R^2",
+    "Information Ratio",
+    "Calmar",
+    "Skew",
+    "Kurtosis",
+    "Expected Daily",
+    "Expected Monthly",
+    "Expected Yearly",
+    "Kelly Criterion",
+    "Risk of Ruin",
+    "Daily Value-at-Risk",
+    "Expected Shortfall (cVaR)",
+    "Max Consecutive Wins",
+    "Max Consecutive Losses",
+    "Gain/Pain Ratio",
+    "Gain/Pain (1M)",
+    "Payoff Ratio",
+    "Profit Factor",
+    "Common Sense Ratio",
+    "CPC Index",
+    "Tail Ratio",
+    "Outlier Win Ratio",
+    "Outlier Loss Ratio",
+    "MTD",
+    "3M",
+    "6M",
+    "YTD",
+    "1Y",
+    "3Y (ann.)",
+    "5Y (ann.)",
+    "10Y (ann.)",
+    "All-time (ann.)",
+    "Best Day",
+    "Worst Day",
+    "Best Month",
+    "Worst Month",
+    "Best Year",
+    "Worst Year",
+    "Avg. Drawdown",
+    "Avg. Drawdown Days",
+    "Recovery Factor",
+    "Ulcer Index",
+    "Serenity Index",
+    "Avg. Up Month",
+    "Avg. Down Month",
+    "Win Days",
+    "Win Month",
+    "Win Quarter",
+    "Win Year",
+    "Beta",
+    "Alpha",
+    "Correlation",
+    "Treynor Ratio",
+]
+
+
 def assert_close(actual: object, expected: object, rel: float = 1e-9) -> None:
     actual_float = float(cast(SupportsFloat, actual))
     expected_float = float(cast(SupportsFloat, expected))
@@ -324,6 +437,18 @@ def test_basic_report_metrics_match_quantstats_values() -> None:
         assert actual_by_metric[metric]["Strategy"] == str(expected.loc[metric, "Strategy"])
 
 
+def test_basic_report_preserves_legacy_metric_order() -> None:
+    actual = reports.metrics(
+        to_polars_frame(returns_series()),
+        benchmark=to_polars_frame(benchmark_series(), "benchmark"),
+        display=False,
+        mode="basic",
+    )
+
+    assert actual is not None
+    assert actual["Metric"].to_list() == LEGACY_BASIC_REPORT_METRICS
+
+
 def test_full_report_metrics_include_benchmark_relative_rows() -> None:
     pandas_returns = returns_series()
     pandas_benchmark = benchmark_series()
@@ -359,3 +484,15 @@ def test_full_report_metrics_include_benchmark_relative_rows() -> None:
     for metric in ["R^2", "Information Ratio"]:
         assert actual_by_metric[metric]["Benchmark"] == "-"
         assert actual_by_metric[metric]["Strategy"] == str(expected.loc[metric, "Strategy"])
+
+
+def test_full_report_preserves_legacy_metric_order() -> None:
+    actual = reports.metrics(
+        to_polars_frame(returns_series()),
+        benchmark=to_polars_frame(benchmark_series(), "benchmark"),
+        display=False,
+        mode="full",
+    )
+
+    assert actual is not None
+    assert actual["Metric"].to_list() == LEGACY_FULL_REPORT_METRICS

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "alphastats"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },


### PR DESCRIPTION
**리뷰어가 작업내용을 이해하기 쉽도록 아래내용을 상세히 작성해주세요.**

## Changes

- `reports.metrics()`의 basic/full report 항목 집합과 순서를 QuantStats legacy report와 호환되도록 조정했습니다.
- 클라이언트가 reports 배열의 항목과 순서에 의존하는 케이스를 위해, `Max DD Date`, `Max DD Period Start`, `Max DD Period End`, `Avg. Return`, `Avg. Win`, `Avg. Loss` row를 제거하고 `Expected Daily`, `Expected Monthly`, `Expected Yearly` row를 복원했습니다.
- legacy basic/full report metric order를 테스트로 고정했습니다.
- patch 버전을 `0.2.1`로 올렸습니다.

## Test

> **💡** _진행한 테스트에 대해서 구체적으로 작성해주세요._

- `uv run pytest -q`
- `uv run ruff check alphastats/reports.py tests/test_quantstats_parity.py`
- `uv run mypy alphastats tests/test_quantstats_parity.py`
- QuantStats `0.0.62`와 basic/full reports row 개수 및 순서가 일치하는 것을 로컬 스크립트로 확인했습니다.

## Task Link

> **💡** _관련 페이지 링크를 작성해주세요._

- N/A